### PR TITLE
Added support for 48 flaps per module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![format badge](https://github.com/jhoff/Split-Flap-Display/actions/workflows/format-check.yml/badge.svg?branch=main)
 [![](https://dcbadge.limes.pink/api/server/https://discord.gg/RCvks4XXXH?style=flat)](https://discord.gg/RCvks4XXXH)
 
-
 Looking for support? Find help on discord ☝️
 
 Firmware for the modular Split Flap Display created by [Morgan Manly](https://github.com/ManlyMorgan/Split-Flap-Display)

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -160,7 +160,18 @@ void SplitFlapDisplay::writeChar(char inputChar, float speed) {
     moveTo(targetPositions, speed);
 }
 
+String sanitizeInput(const String &input) {
+    String sanitized = input;
+
+    // Replace problematic characters
+    sanitized.replace("'", "'\\'");
+    sanitized.replace("%", "%%");
+
+    return sanitized;
+}
+
 void SplitFlapDisplay::writeString(String inputString, float speed, bool centering) {
+    inputString = sanitizeInput(inputString);
     String displayString = inputString.substring(0, numModules);
 
     if (centering) {

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -32,7 +32,9 @@ void SplitFlapDisplay::init() {
     Serial.println();
 
     for (uint8_t i = 0; i < numModules; i++) {
-        modules[i] = SplitFlapModule(moduleAddresses[i], stepsPerRot, moduleOffsets[i] + displayOffset, magnetPosition, charSetSize);
+        modules[i] = SplitFlapModule(
+            moduleAddresses[i], stepsPerRot, moduleOffsets[i] + displayOffset, magnetPosition, charSetSize
+        );
     }
 
     SDAPin = settings.getInt("sdaPin");

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -12,6 +12,7 @@ void SplitFlapDisplay::init() {
     displayOffset = settings.getInt("displayOffset");
     magnetPosition = settings.getInt("magnetPosition");
     maxVel = settings.getFloat("maxVel");
+    charSetSize = settings.getInt("charset");
 
     std::vector<int> settingAddresses = settings.getIntVector("moduleAddresses");
     for (int i = 0; i < numModules; i++) {
@@ -31,7 +32,7 @@ void SplitFlapDisplay::init() {
     Serial.println();
 
     for (uint8_t i = 0; i < numModules; i++) {
-        modules[i] = SplitFlapModule(moduleAddresses[i], stepsPerRot, moduleOffsets[i] + displayOffset, magnetPosition);
+        modules[i] = SplitFlapModule(moduleAddresses[i], stepsPerRot, moduleOffsets[i] + displayOffset, magnetPosition, charSetSize);
     }
 
     SDAPin = settings.getInt("sdaPin");

--- a/src/SplitFlapDisplay.h
+++ b/src/SplitFlapDisplay.h
@@ -33,6 +33,7 @@ class SplitFlapDisplay {
     void testCount();
     void testRandom(float speed = MAX_RPM);
     int getNumModules() { return numModules; }
+    int getCharsetSize() const { return charSetSize; }
     void setMqtt(SplitFlapMqtt *mqttHandler);
 
   private:
@@ -48,9 +49,10 @@ class SplitFlapDisplay {
     int moduleOffsets[MAX_MODULES];
     int displayOffset;
 
-    float maxVel;    // Max Velocity In RPM
-    int stepsPerRot; // number of motor steps per full rotation of character
-    // drum
+    float maxVel;       // Max Velocity In RPM
+    int charSetSize;    // 37 for standard, 48 for extended
+    int stepsPerRot;    // number of motor steps per full rotation of character
+                        // drum
     int magnetPosition; // position of drum wheel when magnet is detected
     int SDAPin;         // SDA pin
     int SCLPin;         // SCL pin

--- a/src/SplitFlapDisplay.ino
+++ b/src/SplitFlapDisplay.ino
@@ -37,6 +37,7 @@ JsonSettings settings = JsonSettings("config", {
     {"sclPin", JsonSetting(9)},
     {"stepsPerRot", JsonSetting(2048)},
     {"maxVel", JsonSetting(15.0f)},
+    {"charset", JsonSetting(37)},
     // Operational States
     {"mode", JsonSetting(0)}
 });

--- a/src/SplitFlapModule.cpp
+++ b/src/SplitFlapModule.cpp
@@ -3,29 +3,32 @@
 // Array of characters, in order, the first item is located on the magnet on the
 // character drum
 const char SplitFlapModule::StandardChars[37] = {' ', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
-                                         'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
-                                         'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
+                                                 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
+                                                 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
 
-const char SplitFlapModule::ExtendedChars[48] = {' ', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
-                                         'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y',
-                                         'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-                                         '\'', ':', '?', '!', '.', '-', '/', '$', '@', '#', '%',};
-
+const char SplitFlapModule::ExtendedChars[48] = {
+    ' ', 'A', 'B', 'C', 'D', 'E',  'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+    'P', 'Q', 'R', 'S', 'T', 'U',  'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4',
+    '5', '6', '7', '8', '9', '\'', ':', '?', '!', '.', '-', '/', '$', '@', '#', '%',
+};
 
 bool hasErrored = false;
 
 // Default Constructor
-SplitFlapModule::SplitFlapModule() : address(0), position(0), stepNumber(0), stepsPerRot(0), chars(StandardChars), numChars(37), charSetSize(37) {
-  magnetPosition = 710;
+SplitFlapModule::SplitFlapModule()
+    : address(0), position(0), stepNumber(0), stepsPerRot(0), chars(StandardChars), numChars(37), charSetSize(37) {
+    magnetPosition = 710;
 }
 
 // Constructor implementation
-SplitFlapModule::SplitFlapModule(uint8_t I2Caddress, int stepsPerFullRotation, int stepOffset, int magnetPos, int charsetSize)
+SplitFlapModule::SplitFlapModule(
+    uint8_t I2Caddress, int stepsPerFullRotation, int stepOffset, int magnetPos, int charsetSize
+)
     : address(I2Caddress), position(0), stepNumber(0), stepsPerRot(stepsPerFullRotation), charSetSize(charsetSize) {
-  magnetPosition = magnetPos + stepOffset;
+    magnetPosition = magnetPos + stepOffset;
 
-  chars = (charsetSize == 48) ? ExtendedChars : StandardChars;
-  numChars = (charsetSize == 48) ? 48 : 37;
+    chars = (charsetSize == 48) ? ExtendedChars : StandardChars;
+    numChars = (charsetSize == 48) ? 48 : 37;
 }
 
 void SplitFlapModule::writeIO(uint16_t data) {
@@ -51,11 +54,11 @@ void SplitFlapModule::writeIO(uint16_t data) {
 
 // Init Module, Setup IO Board
 void SplitFlapModule::init() {
-    float stepSize = (float)stepsPerRot / (float)numChars;
+    float stepSize = (float) stepsPerRot / (float) numChars;
     float currentPosition = 0;
     for (int i = 0; i < numChars; i++) {
-      charPositions[i] = (int)currentPosition;
-      currentPosition += stepSize;
+        charPositions[i] = (int) currentPosition;
+        currentPosition += stepSize;
     }
 
     uint16_t initState = 0b1111111111100001; // Pin 15 (17) as INPUT, Pins 1-4 as OUTPUT

--- a/src/SplitFlapModule.h
+++ b/src/SplitFlapModule.h
@@ -8,7 +8,7 @@ class SplitFlapModule {
     // Constructor declarationS
     SplitFlapModule(); // default constructor required to allocate memory for
     // SplitFlapDisplay class
-    SplitFlapModule(uint8_t I2Caddress, int stepsPerFullRotation, int stepOffset, int magnetPos);
+    SplitFlapModule(uint8_t I2Caddress, int stepsPerFullRotation, int stepOffset, int magnetPos, int charSetSize);
 
     void init();
 
@@ -19,6 +19,7 @@ class SplitFlapModule {
     int getMagnetPosition() const { return magnetPosition; } // position where magnet is detected
     int getCharPosition(char inputChar);                     // get integer position given single character
     int getPosition() const { return position; }             // get integer position
+    int getCharsetSize() const { return numChars; } // getter for charset size
 
     bool readHallEffectSensor();                             // return the value read by the hall effect
     // sensor
@@ -41,10 +42,13 @@ class SplitFlapModule {
     static const int motorPins[];   // Array of motor pins
     static const int HallEffectPIN; // Hall Effect Sensor Pin (On PCF8575)
 
-    static const char chars[37];    // all characters in order
-    static int charPositions[37];   // will be generated based on the characters and
-    // the magnetPosition variable
-    static const int numChars; // number of characters in module
+    const char* chars;             // pointer to active character set
+    int charPositions[48];         // support up to 48 characters
+    int numChars;                  // current number of characters
+    int charSetSize;
+
+    static const char StandardChars[37];
+    static const char ExtendedChars[48];
 };
 
 // //PINs on the PCF8575 Board

--- a/src/SplitFlapModule.h
+++ b/src/SplitFlapModule.h
@@ -19,7 +19,7 @@ class SplitFlapModule {
     int getMagnetPosition() const { return magnetPosition; } // position where magnet is detected
     int getCharPosition(char inputChar);                     // get integer position given single character
     int getPosition() const { return position; }             // get integer position
-    int getCharsetSize() const { return numChars; } // getter for charset size
+    int getCharsetSize() const { return numChars; }          // getter for charset size
 
     bool readHallEffectSensor();                             // return the value read by the hall effect
     // sensor
@@ -42,9 +42,9 @@ class SplitFlapModule {
     static const int motorPins[];   // Array of motor pins
     static const int HallEffectPIN; // Hall Effect Sensor Pin (On PCF8575)
 
-    const char* chars;             // pointer to active character set
-    int charPositions[48];         // support up to 48 characters
-    int numChars;                  // current number of characters
+    const char *chars;              // pointer to active character set
+    int charPositions[48];          // support up to 48 characters
+    int numChars;                   // current number of characters
     int charSetSize;
 
     static const char StandardChars[37];

--- a/src/web/settings.html
+++ b/src/web/settings.html
@@ -42,6 +42,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="text"
+                id="name"
                 x-model="settings.name"
                 placeholder="Enter a name for this display"
             />
@@ -58,6 +59,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="text"
+                id="mdns"
                 x-model="settings.mdns"
                 placeholder="Enter mDNS hostname"
             />
@@ -74,6 +76,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="text"
+                id="otaPass"
                 x-model="settings.otaPass"
                 placeholder="Enter OTA Password"
             />
@@ -91,6 +94,7 @@
                 <select
                     class="w-full p-3 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                     x-model="settings.timezone"
+                    id="timezone"
                 >
                     <template x-for="(name, zone) in timezones" :key="zone">
                         <option
@@ -217,6 +221,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="number"
+                id="moduleCount"
                 x-model="settings.moduleCount"
                 min="1"
                 max="8"
@@ -229,12 +234,25 @@
                 x-text="errors.message"
             ></div>
 
+            <label for="charset" class="block text-left text-lg mt-4"
+                >Character Set</label
+            >
+            <select
+                class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-white"
+                x-model="settings.charset"
+                id="charset"
+            >
+                <option value="37">Standard (37)</option>
+                <option value="48">Extended (48)</option>
+            </select>
+
             <label for="moduleAddresses" class="block text-left text-lg mt-4"
                 >Module Addresses (comma-separated)</label
             >
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="text"
+                id="moduleAddresses"
                 x-model="settings.moduleAddresses"
                 placeholder="Enter addresses"
             />
@@ -251,6 +269,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="number"
+                id="magnetPosition"
                 x-model="settings.magnetPosition"
                 placeholder="Enter magnet position"
             />
@@ -267,6 +286,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="text"
+                id="moduleOffsets"
                 x-model="settings.moduleOffsets"
                 placeholder="Enter module offsets"
             />
@@ -283,6 +303,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="number"
+                id="displayOffset"
                 x-model="settings.displayOffset"
                 placeholder="Enter display offset"
             />
@@ -299,6 +320,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="number"
+                id="sdaPin"
                 x-model="settings.sdaPin"
                 placeholder="Enter SDA pin"
             />
@@ -315,6 +337,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="number"
+                id="sclPin"
                 x-model="settings.sclPin"
                 placeholder="Enter SCL pin"
             />
@@ -331,6 +354,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="number"
+                id="stepsPerRot"
                 x-model="settings.stepsPerRot"
                 placeholder="Enter steps per rotation"
             />
@@ -347,6 +371,7 @@
             <input
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-gray-100"
                 type="number"
+                id="maxVel"
                 step="0.1"
                 x-model="settings.maxVel"
                 placeholder="Enter max velocity"
@@ -437,6 +462,8 @@
                     save() {
                         this.saving = true;
                         this.errors = {};
+                        this.settings.charset = parseInt(this.settings.charset);
+
                         fetch("/settings", {
                             method: "POST",
                             headers: { "Content-Type": "application/json" },

--- a/src/web/settings.html
+++ b/src/web/settings.html
@@ -239,7 +239,7 @@
             >
             <select
                 class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-gray-700 text-white"
-                x-model="settings.charset"
+                x-model.number="settings.charset"
                 id="charset"
             >
                 <option value="37">Standard (37)</option>
@@ -462,7 +462,6 @@
                     save() {
                         this.saving = true;
                         this.errors = {};
-                        this.settings.charset = parseInt(this.settings.charset);
 
                         fetch("/settings", {
                             method: "POST",


### PR DESCRIPTION
This adds support for a version of the module with 48 flaps I'm currently making. (So it can have flaps for special characters)
The default is still the standard 37 but this will add an option in the settings to enable the extended charset.

Currently these changes support the following characters ' : ? ! . - / $ @ # %   but ideally we would make the charset configurable at some point so also other alphabets are possible.

I've designed a bigger version of the enclosure and flap drum which I'll be happy to share as a remix / upgrade kit. 

Because there is also internally a bit more space, it makes wiring a bit easier and I've added a slot that can fit the multiplexer board as well (for future-proofing)

I'm currently still finalising testing (results are good so far), but I also want to test on the standard version to make sure it is fully backwards compatible.

This PR is for now mainly to notify that it's being worked on.

Please let me know if you already have any suggestions/feedback. 