### PR TITLE
fix: avoid startup current spike on multi-module displays

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Automatically normalize line endings for all text files (recommends LF in repo)
+* text=auto
+
+# Shell scripts must strictly use LF to execute on macOS/Linux
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Windows batch files must strictly use CRLF to execute on Windows
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Data & Configuration Formats
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.toml text eol=lf
+*.md text eol=lf

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Firmware for the modular Split Flap Display created by [Morgan Manly](https://gi
 - Fully configurable and controllable via Web Interface
     - Switch Between Operation Modes, modes include custom input, date mode, and time mode
     - Configure WiFi, Timezone, and hardware settings
+- Per-module and per-character offset tuning for precise flap alignment
 - MQTT Support
-- OTA Firmware / Filesystem updating
 - Scrolling text for messages longer than the display width, with configurable delay between chunks and configurable repeat count
 - Multi-display master mode using ESP-NOW to coordinate up to 6 display groups, with up to 8 modules per group
 
@@ -126,11 +126,24 @@ Group 1 displays its segment locally on the master controller. The master sends 
 
 Remote groups automatically switch into ESP-NOW remote display mode when they receive a message from the master. They do not need their own text entry once registered with the master.
 
-### Using OTA to update the firmware
+## Tuning
 
-On the settings page set an OTA password to enable OTA updatable firmware. Use this same password for your `auth` flag in `platformio.ini`, and then use a device environment with `*_ota` appended (ie `esp32_s3_ota`) to upload a new firmware and/or filesystem.
+The settings page provides two levels of offset adjustment for precise flap alignment:
 
-Note: the default `esp32_c3` environment uses a no-OTA partition layout to fit the current firmware on 4MB C3 boards. OTA updates need two app slots, so they are not supported by that default C3 layout unless the firmware/filesystem size is reduced or a larger-flash board/layout is used.
+### Module Offsets
+
+Each module has a coarse offset that adjusts the home position (magnet detection point). This shifts all characters on that module by the same amount. Use this when an entire module's display is consistently off by a few steps. Changes take effect immediately after saving settings.
+
+### Character Offsets
+
+Each character on each module can be individually tuned. This is useful when specific characters are misaligned while others are correct. In the settings page:
+
+1. Expand the module you want to tune
+2. Use the ▲/▼ arrows or enter values directly to adjust each character's position by individual motor steps
+3. Use **Reset** to zero all offsets for a module
+4. Use **Copy from** to duplicate another module's offsets
+
+Changes take effect immediately after saving settings—no reboot required. Offsets are stored per-module and persist across reboots.
 
 ## Contributing
 
@@ -156,3 +169,21 @@ Note: the default `esp32_c3` environment uses a no-OTA partition layout to fit t
 
 1. When ready, commit and push your changes to your forked repository.
 1. Open a pull request to this repository.
+
+### Running Tests
+
+The project includes unit tests for the frontend JavaScript logic. Tests use [Vitest](https://vitest.dev/) with jsdom environment.
+
+Run all tests:
+
+```sh
+npm test
+```
+
+Run tests in watch mode (re-runs on file changes):
+
+```sh
+npm run test:watch
+```
+
+Tests cover the Alpine.js component logic including settings management, character offset calculations, and API interactions with mocked fetch calls.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Firmware for the modular Split Flap Display created by [Morgan Manly](https://gi
 - MQTT Support
 - OTA Firmware / Filesystem updating
 - Scrolling text for messages longer than the display width, with configurable delay between chunks and configurable repeat count
+- Multi-display master mode using ESP-NOW to coordinate up to 6 display groups, with up to 8 modules per group
 
 ## Supported boards
 
@@ -31,6 +32,26 @@ Firmware for the modular Split Flap Display created by [Morgan Manly](https://gi
 | `esp32_s3`           | ESP32-S3FH4R2 | Waveshare ESP32-S3-Zero<sup>\*</sup><br>ESP32-S3 Super Mini<sup>\*</sup> |
 
 <sub>\* Requires manually resetting the board into firmware upload mode by holding BOOT, pressing & releasing RESET, then releasing BOOT prior to upload. After uploading is successful, either press & release RESET or power cycle the board to put it in normal operation mode.</sub>
+
+### ESP32-C3 partition layout
+
+The default `esp32_c3` environment uses `no_ota.csv`. This gives the 4MB ESP32-C3 boards a larger single app partition for the current firmware and web feature set. Without this layout, the firmware can outgrow the default OTA app slot and the board may repeatedly reset before `setup()` runs.
+
+Because this layout changes the flash partition table, erase the board before uploading firmware built with it:
+
+```sh
+pio run -t erase -e esp32_c3
+pio run -t upload -e esp32_c3
+pio run -t uploadfs -e esp32_c3
+```
+
+After flashing, monitor the C3 environment at `460800` baud:
+
+```sh
+pio device monitor -e esp32_c3 -b 460800
+```
+
+The erase step clears saved settings, Wi-Fi credentials, NVS data, and the filesystem. Upload both firmware and filesystem afterward.
 
 ## Setup Instructions
 
@@ -51,11 +72,65 @@ Firmware for the modular Split Flap Display created by [Morgan Manly](https://gi
 - Compiles and uploads the esp32 firmware ( `npm run pio:firmware` or `pio run -t upload -e <environment>` )
 - Compiles and uploads the littlefs filesystem ( `npm run pio:filesystem` or `pio run -t uploadfs -e <environment>` )
 
+If you are switching an ESP32-C3 board from an older build or partition layout, use the erase/upload sequence in [ESP32-C3 partition layout](#esp32-c3-partition-layout) instead of only running `npm run build`.
+
 1. Enjoy!
+
+## Multi-Display Master Mode
+
+The firmware can coordinate multiple split-flap display groups from one master controller. This is useful when a single hardware group cannot exceed 8 modules, but the full message needs to span more modules.
+
+Limits:
+
+- Up to 8 modules per group
+- Up to 6 groups total
+- Up to 48 modules total when all 6 groups have 8 modules
+- Group 1 is always the local group connected to the master controller
+- Groups 2-6 are remote groups controlled over ESP-NOW
+
+All controllers run the same firmware. The master is simply the controller where `Number of Groups` is set above `1`.
+
+### How messages are split
+
+When custom text is submitted from the master web page, the text is split from left to right using each group's configured module count.
+
+For example, with these group sizes:
+
+| Group | Modules | Displayed segment |
+| ----- | ------- | ----------------- |
+| 1     | 8       | Characters 1-8    |
+| 2     | 6       | Characters 9-14   |
+| 3     | 8       | Characters 15-22  |
+
+Group 1 displays its segment locally on the master controller. The master sends each remaining segment to the configured remote group MAC address over ESP-NOW. Short segments are padded with spaces. Characters beyond the total configured module count are not sent.
+
+### Setup
+
+1. Flash the firmware and filesystem to every group controller.
+1. Configure Wi-Fi on every controller. Using the same Wi-Fi network is recommended so the controllers share a radio channel and each web page remains reachable.
+1. Open the serial monitor for each remote controller and note the MAC address printed at startup:
+
+    - `[esp-now] initialized on AA:BB:CC:DD:EE:FF`
+
+1. On the master controller, open `Settings`.
+1. In `Hardware Settings`, set `Number of Modules` to the number of modules physically connected to the master group.
+1. In `Multi-Display Master`, set `Number of Groups`.
+1. For each group:
+
+    - Set the module count for that group.
+    - Leave Group 1 as the local display.
+    - Enter the ESP-NOW MAC address for each remote group.
+
+1. Save settings.
+1. Return to the main page, select `Custom Text`, enter the full message, and click `Update Display`.
+
+Remote groups automatically switch into ESP-NOW remote display mode when they receive a message from the master. They do not need their own text entry once registered with the master.
 
 ### Using OTA to update the firmware
 
-On the settings page set an OTA password to enable OTA updatable firmware. Use this same password for your `auth` flag in `platformio.ini`, and then use a device environment with `*_ota` appended (ie `esp32_s3_ota`) to upload a new firmware and/or filesystem
+On the settings page set an OTA password to enable OTA updatable firmware. Use this same password for your `auth` flag in `platformio.ini`, and then use a device environment with `*_ota` appended (ie `esp32_s3_ota`) to upload a new firmware and/or filesystem.
+
+Note: the default `esp32_c3` environment uses a no-OTA partition layout to fit the current firmware on 4MB C3 boards. OTA updates need two app slots, so they are not supported by that default C3 layout unless the firmware/filesystem size is reduced or a larger-flash board/layout is used.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Group 1 displays its segment locally on the master controller. The master sends 
 
 1. Flash the firmware and filesystem to every group controller.
 1. Configure Wi-Fi on every controller. Using the same Wi-Fi network is recommended so the controllers share a radio channel and each web page remains reachable.
-1. Open the serial monitor for each remote controller and note the MAC address printed at startup:
+1. Open the serial monitor for each remote controller and note the MAC address printed at startup (also shown on the Settings page):
 
     - `[esp-now] initialized on AA:BB:CC:DD:EE:FF`
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Firmware for the modular Split Flap Display created by [Morgan Manly](https://gi
     - Configure WiFi, Timezone, and hardware settings
 - MQTT Support
 - OTA Firmware / Filesystem updating
+- Scrolling text for messages longer than the display width, with configurable delay between chunks and configurable repeat count
 
 ## Supported boards
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Firmware for the modular Split Flap Display created by [Morgan Manly](https://gi
 - Fully configurable and controllable via Web Interface
     - Switch Between Operation Modes, modes include custom input, date mode, and time mode
     - Configure WiFi, Timezone, and hardware settings
-- Per-module and per-character offset tuning for precise flap alignment
 - MQTT Support
-- Scrolling text for messages longer than the display width, with configurable delay between chunks and configurable repeat count
 - Multi-display master mode using ESP-NOW to coordinate up to 6 display groups, with up to 8 modules per group
+- Per-module and per-character offset tuning for precise flap alignment
+- Scrolling text for messages longer than the display width, with configurable delay between chunks and configurable repeat count
 
 ## Supported boards
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,23 @@ Each character on each module can be individually tuned. This is useful when spe
 
 Changes take effect immediately after saving settings—no reboot required. Offsets are stored per-module and persist across reboots.
 
+### Power / Startup Settings
+
+Larger displays (many modules on one 5V rail) can trip their power supply
+at boot when every motor coil is energized at once. Two settings help:
+
+- **Boot Delay (ms)** — extra settle time after power-on before the
+  network bring-up starts. Motor coils are powered down immediately at
+  boot (before this delay), so the delay costs almost no current. In
+  multi-display setups, set the slave's `bootDelayMs` a few seconds
+  higher than the master's so the two boards never home at the same time.
+- **Max Motors At Once (homing)** — caps how many motors are energized
+  simultaneously during the boot homing sweep (and offset-reload homing).
+  Lower = gentler on the supply, slower homing. Default 2. Normal message
+  writes are unaffected (motors only draw current while actually moving).
+
+Requires a reboot after changing either setting.
+
 ## Contributing
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Group 1 displays its segment locally on the master controller. The master sends 
 
 1. Flash the firmware and filesystem to every group controller.
 1. Configure Wi-Fi on every controller. Using the same Wi-Fi network is recommended so the controllers share a radio channel and each web page remains reachable.
-1. Open the serial monitor for each remote controller and note the MAC address printed at startup (also shown on the Settings page):
+1. The MAC address can be found when you access the Main or the Settings page. Alternatively, you can open the serial monitor for each remote controller and note the MAC address printed at startup:
 
     - `[esp-now] initialized on AA:BB:CC:DD:EE:FF`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,12 @@
             "version": "1.0.0",
             "devDependencies": {
                 "@tailwindcss/vite": "^4.0.17",
+                "@testing-library/dom": "^10.4.1",
+                "@testing-library/jest-dom": "^6.9.1",
                 "alpinejs": "^3.14.9",
                 "autoprefixer": "^10.4.21",
                 "html-minifier-terser": "^7.2.0",
+                "jsdom": "^29.1.1",
                 "jsonminify": "^0.4.2",
                 "postcss": "^8.5.3",
                 "prettier": "^3.5.3",
@@ -19,7 +22,254 @@
                 "tailwindcss": "^4.0.17",
                 "vite": "^6.2.3",
                 "vite-plugin-html": "^3.2.2",
-                "vite-plugin-static-copy": "^2.3.0"
+                "vite-plugin-static-copy": "^2.3.0",
+                "vitest": "^4.1.9"
+            }
+        },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+            "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+            "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+            "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.1.0",
+                "@csstools/css-calc": "^3.2.1"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+            "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -447,6 +697,24 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+            "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -494,9 +762,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
         },
@@ -843,6 +1111,13 @@
                 "win32"
             ]
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@tailwindcss/node": {
             "version": "4.0.17",
             "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.0.17.tgz",
@@ -1081,12 +1356,221 @@
                 "vite": "^5.2.0 || ^6"
             }
         },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+            "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@adobe/css-tools": "^4.4.0",
+                "aria-query": "^5.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "picocolors": "^1.1.1",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.9",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.9",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.9",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
         },
         "node_modules/@vue/reactivity": {
             "version": "3.1.5",
@@ -1128,6 +1612,16 @@
                 "@vue/reactivity": "~3.1.1"
             }
         },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1156,6 +1650,26 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/async": {
@@ -1209,6 +1723,16 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
+            }
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
@@ -1326,6 +1850,16 @@
             ],
             "license": "CC-BY-4.0"
         },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1442,6 +1976,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/css-select": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -1459,6 +2000,20 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/css-what": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -1472,6 +2027,44 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/detect-libc": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -1481,6 +2074,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/dom-serializer": {
             "version": "1.4.1",
@@ -1635,6 +2235,13 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/esbuild": {
             "version": "0.25.1",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
@@ -1692,6 +2299,16 @@
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -1850,6 +2467,19 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/html-minifier-terser": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
@@ -1870,6 +2500,16 @@
             },
             "engines": {
                 "node": "^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-binary-path": {
@@ -1918,6 +2558,13 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/jake": {
             "version": "10.9.2",
             "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
@@ -1945,6 +2592,54 @@
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "29.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.1.11",
+                "@asamuzakjp/dom-selector": "^7.1.1",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+                "@exodus/bytes": "^1.15.0",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.3.5",
+                "parse5": "^8.0.1",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.1",
+                "undici": "^7.25.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.1",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
             }
         },
         "node_modules/jsonfile": {
@@ -2220,6 +2915,43 @@
                 "tslib": "^2.0.3"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2242,6 +2974,16 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/minimatch": {
@@ -2338,6 +3080,20 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/p-map": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
@@ -2360,6 +3116,32 @@
             "dependencies": {
                 "dot-case": "^3.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/pascal-case": {
@@ -2462,6 +3244,44 @@
                 "prettier": ">=3.0.0-alpha.3"
             }
         },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2483,6 +3303,13 @@
             ],
             "license": "MIT"
         },
+        "node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2496,6 +3323,20 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/relateurl": {
             "version": "0.2.7",
             "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -2504,6 +3345,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/reusify": {
@@ -2581,6 +3432,26 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2612,6 +3483,33 @@
                 "source-map": "^0.6.0"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2624,6 +3522,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tailwindcss": {
             "version": "4.0.17",
@@ -2668,6 +3573,101 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tldts": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.6.tgz",
+            "integrity": "sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.4.6"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.6.tgz",
+            "integrity": "sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2681,12 +3681,48 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tough-cookie": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
             "license": "0BSD"
+        },
+        "node_modules/undici": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
         },
         "node_modules/universalify": {
             "version": "2.0.1",
@@ -2891,6 +3927,198 @@
             "engines": {
                 "node": ">=14.14"
             }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.9",
+                "@vitest/mocker": "4.1.9",
+                "@vitest/pretty-format": "4.1.9",
+                "@vitest/runner": "4.1.9",
+                "@vitest/snapshot": "4.1.9",
+                "@vitest/spy": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.9",
+                "@vitest/browser-preview": "4.1.9",
+                "@vitest/browser-webdriverio": "4.1.9",
+                "@vitest/coverage-istanbul": "4.1.9",
+                "@vitest/coverage-v8": "4.1.9",
+                "@vitest/ui": "4.1.9",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,18 @@
         "pio": "npm run pio:firmware && sleep 2 && npm run pio:filesystem",
         "pio:firmware": "pio run -t upload",
         "pio:filesystem": "pio run -t uploadfs",
-        "pio:monitor": "pio device monitor"
+        "pio:monitor": "pio device monitor",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.17",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
         "alpinejs": "^3.14.9",
         "autoprefixer": "^10.4.21",
         "html-minifier-terser": "^7.2.0",
+        "jsdom": "^29.1.1",
         "jsonminify": "^0.4.2",
         "postcss": "^8.5.3",
         "prettier": "^3.5.3",
@@ -24,7 +29,8 @@
         "tailwindcss": "^4.0.17",
         "vite": "^6.2.3",
         "vite-plugin-html": "^3.2.2",
-        "vite-plugin-static-copy": "^2.3.0"
+        "vite-plugin-static-copy": "^2.3.0",
+        "vitest": "^4.1.9"
     },
     "prettier": {
         "plugins": [

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,7 @@ upload_port=splitflap.local
 [env:esp32_c3]
 extends=env
 board=esp32-c3-devkitm-1
+board_build.partitions=no_ota.csv
 monitor_speed=460800
 
 build_flags=

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,6 @@ lib_deps=
     hmueller01/PubSubClient3
 
 build_flags=
-    '-D STARTUP_DELAY=2000'
     ; '-D WIFI_SSID="MySsid"' ; hardcoded wifi credentials
     ; '-D WIFI_PASS="123456"' ; ( for settings development )
 

--- a/src/JsonSetting.cpp
+++ b/src/JsonSetting.cpp
@@ -11,9 +11,24 @@ String JsonSetting::intVectorToString(const std::vector<int> &vec) {
     return result;
 }
 
+String JsonSetting::intMatrixToString(const std::vector<std::vector<int>> &mat) {
+    String result;
+    for (size_t r = 0; r < mat.size(); ++r) {
+        if (r > 0) result += ";";
+        for (size_t c = 0; c < mat[r].size(); ++c) {
+            result += String(mat[r][c]);
+            if (c < mat[r].size() - 1) {
+                result += ",";
+            }
+        }
+    }
+    return result;
+}
+
 bool JsonSetting::validate(String str) {
     switch (type) {
         case JsonSettingType::JST_INT_VECTOR: return validateIntVector(str);
+        case JsonSettingType::JST_INT_MATRIX: return validateIntMatrix(str);
         default: return true;
     }
 }
@@ -25,6 +40,19 @@ bool JsonSetting::validateIntVector(String str) {
         }
         if (str[i] < '0' || str[i] > '9') {
             lastValidationError = "Non-integer value found";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool JsonSetting::validateIntMatrix(String str) {
+    for (size_t i = 0; i < str.length(); ++i) {
+        if (str[i] == ',' || str[i] == ';' || str[i] == '-') {
+            continue;
+        }
+        if (str[i] < '0' || str[i] > '9') {
+            lastValidationError = "Non-integer value found in matrix";
             return false;
         }
     }

--- a/src/JsonSetting.h
+++ b/src/JsonSetting.h
@@ -7,7 +7,8 @@ typedef enum {
     JST_STR,
     JST_INT,
     JST_FLOAT,
-    JST_INT_VECTOR
+    JST_INT_VECTOR,
+    JST_INT_MATRIX
 } JsonSettingType;
 
 class JsonSetting {
@@ -21,6 +22,10 @@ class JsonSetting {
         : type(JsonSettingType::JST_INT_VECTOR), intVectorDefault(intVectorDefault) {
         strDefault = intVectorToString(intVectorDefault);
     }
+    JsonSetting(std::vector<std::vector<int>> intMatrixDefault)
+        : type(JsonSettingType::JST_INT_MATRIX), intMatrixDefault(intMatrixDefault) {
+        strDefault = intMatrixToString(intMatrixDefault);
+    }
 
     bool validate(String str);
     String getLastValidationError() { return lastValidationError; }
@@ -32,11 +37,14 @@ class JsonSetting {
     int intDefault;
     float floatDefault;
     std::vector<int> intVectorDefault;
+    std::vector<std::vector<int>> intMatrixDefault;
 
     String intVectorToString(const std::vector<int> &vec);
+    String intMatrixToString(const std::vector<std::vector<int>> &mat);
 
     String lastValidationError;
     bool validateIntVector(String str);
+    bool validateIntMatrix(String str);
 
     friend class JsonSettings;
 };

--- a/src/JsonSettings.cpp
+++ b/src/JsonSettings.cpp
@@ -98,6 +98,30 @@ std::vector<int> JsonSettings::getIntVector(const char *key) {
     return intVector;
 }
 
+std::vector<std::vector<int>> JsonSettings::getIntMatrix(const char *key) {
+    String value = getPrefString(key, this->find(key).strDefault);
+
+    std::vector<std::vector<int>> matrix;
+    std::istringstream rowStream(value.c_str());
+    std::string rowStr;
+    while (std::getline(rowStream, rowStr, ';')) {
+        std::vector<int> row;
+        std::istringstream colStream(rowStr.c_str());
+        std::string token;
+        while (std::getline(colStream, token, ',')) {
+            try {
+                row.push_back(std::stoi(token));
+            } catch (const std::invalid_argument &) {
+                throw std::runtime_error("Invalid matrix: Non-integer value found");
+            } catch (const std::out_of_range &) {
+                throw std::runtime_error("Invalid matrix: Integer value out of range");
+            }
+        }
+        matrix.push_back(row);
+    }
+    return matrix;
+}
+
 void JsonSettings::putString(const char *key, String value) {
     putPrefString(key, value);
 }
@@ -121,6 +145,20 @@ void JsonSettings::putIntVector(const char *key, std::vector<int> value) {
     putString(key, stream.str().c_str());
 }
 
+void JsonSettings::putIntMatrix(const char *key, std::vector<std::vector<int>> value) {
+    std::ostringstream stream;
+    for (size_t r = 0; r < value.size(); ++r) {
+        if (r > 0) stream << ";";
+        for (size_t c = 0; c < value[r].size(); ++c) {
+            stream << value[r][c];
+            if (c < value[r].size() - 1) {
+                stream << ",";
+            }
+        }
+    }
+    putString(key, stream.str().c_str());
+}
+
 JsonDocument JsonSettings::toJson() {
     JsonDocument settings;
 
@@ -131,6 +169,7 @@ JsonDocument JsonSettings::toJson() {
         switch (setting.type) {
             case JsonSettingType::JST_STR:
             case JsonSettingType::JST_INT_VECTOR:
+            case JsonSettingType::JST_INT_MATRIX:
                 settings[key] = getPrefString(key.c_str(), setting.strDefault);
                 break;
             case JsonSettingType::JST_INT:
@@ -162,6 +201,7 @@ bool JsonSettings::fromJson(JsonDocument settings) {
 
         switch (setting.type) {
             case JsonSettingType::JST_INT_VECTOR:
+            case JsonSettingType::JST_INT_MATRIX:
             case JsonSettingType::JST_STR:
                 putPrefString(key, kv.value().as<String>());
                 break;

--- a/src/JsonSettings.cpp
+++ b/src/JsonSettings.cpp
@@ -3,31 +3,85 @@
 #include <ArduinoJson.h>
 #include <sstream>
 
-String JsonSettings::getString(const char *key) {
+String JsonSettings::storageKey(const char *key) {
+    String storage = String(key);
+    if (storage.length() <= 15) {
+        return storage;
+    }
+
+    unsigned int hash = 5381;
+    for (size_t i = 0; i < storage.length(); ++i) {
+        hash = ((hash << 5) + hash) + storage[i];
+    }
+
+    String suffix = String(hash & 0xFFFF, HEX);
+    suffix.toUpperCase();
+    while (suffix.length() < 4) {
+        suffix = String("0") + suffix;
+    }
+
+    return storage.substring(0, 11) + suffix;
+}
+
+String JsonSettings::getPrefString(const char *key, const String &def) {
+    String storeKey = storageKey(key);
     preferences.begin(name, true);
-    String value = preferences.getString(key, this->find(key).strDefault);
+    String value = preferences.isKey(storeKey.c_str()) ? preferences.getString(storeKey.c_str(), def) : def;
     preferences.end();
     return value;
+}
+
+int JsonSettings::getPrefInt(const char *key, int def) {
+    String storeKey = storageKey(key);
+    preferences.begin(name, true);
+    int value = preferences.getInt(storeKey.c_str(), def);
+    preferences.end();
+    return value;
+}
+
+float JsonSettings::getPrefFloat(const char *key, float def) {
+    String storeKey = storageKey(key);
+    preferences.begin(name, true);
+    float value = preferences.getFloat(storeKey.c_str(), def);
+    preferences.end();
+    return value;
+}
+
+void JsonSettings::putPrefString(const char *key, const String &value) {
+    String storeKey = storageKey(key);
+    preferences.begin(name, false);
+    preferences.putString(storeKey.c_str(), value);
+    preferences.end();
+}
+
+void JsonSettings::putPrefInt(const char *key, int value) {
+    String storeKey = storageKey(key);
+    preferences.begin(name, false);
+    preferences.putInt(storeKey.c_str(), value);
+    preferences.end();
+}
+
+void JsonSettings::putPrefFloat(const char *key, float value) {
+    String storeKey = storageKey(key);
+    preferences.begin(name, false);
+    preferences.putFloat(storeKey.c_str(), value);
+    preferences.end();
+}
+
+String JsonSettings::getString(const char *key) {
+    return getPrefString(key, this->find(key).strDefault);
 }
 
 int JsonSettings::getInt(const char *key) {
-    preferences.begin(name, true);
-    int value = preferences.getInt(key, this->find(key).intDefault);
-    preferences.end();
-    return value;
+    return getPrefInt(key, this->find(key).intDefault);
 }
 
 float JsonSettings::getFloat(const char *key) {
-    preferences.begin(name, true);
-    float value = preferences.getFloat(key, this->find(key).floatDefault);
-    preferences.end();
-    return value;
+    return getPrefFloat(key, this->find(key).floatDefault);
 }
 
 std::vector<int> JsonSettings::getIntVector(const char *key) {
-    preferences.begin(name, true);
-    String value = preferences.getString(key, this->find(key).strDefault);
-    preferences.end();
+    String value = getPrefString(key, this->find(key).strDefault);
 
     std::vector<int> intVector;
     std::istringstream stream(value.c_str());
@@ -45,21 +99,15 @@ std::vector<int> JsonSettings::getIntVector(const char *key) {
 }
 
 void JsonSettings::putString(const char *key, String value) {
-    preferences.begin(name, false);
-    preferences.putString(key, value);
-    preferences.end();
+    putPrefString(key, value);
 }
 
 void JsonSettings::putInt(const char *key, int value) {
-    preferences.begin(name, false);
-    preferences.putInt(key, value);
-    preferences.end();
+    putPrefInt(key, value);
 }
 
 void JsonSettings::putFloat(const char *key, float value) {
-    preferences.begin(name, false);
-    preferences.putFloat(key, value);
-    preferences.end();
+    putPrefFloat(key, value);
 }
 
 void JsonSettings::putIntVector(const char *key, std::vector<int> value) {
@@ -76,8 +124,6 @@ void JsonSettings::putIntVector(const char *key, std::vector<int> value) {
 JsonDocument JsonSettings::toJson() {
     JsonDocument settings;
 
-    preferences.begin(name, true);
-
     for (const auto &pair : map) {
         const String &key = pair.first;
         const JsonSetting &setting = pair.second;
@@ -85,25 +131,28 @@ JsonDocument JsonSettings::toJson() {
         switch (setting.type) {
             case JsonSettingType::JST_STR:
             case JsonSettingType::JST_INT_VECTOR:
-                settings[key] = preferences.getString(key.c_str(), setting.strDefault);
+                settings[key] = getPrefString(key.c_str(), setting.strDefault);
                 break;
-            case JsonSettingType::JST_INT: settings[key] = preferences.getInt(key.c_str(), setting.intDefault); break;
+            case JsonSettingType::JST_INT:
+                settings[key] = getPrefInt(key.c_str(), setting.intDefault);
+                break;
             case JsonSettingType::JST_FLOAT:
-                settings[key] = preferences.getFloat(key.c_str(), setting.floatDefault);
+                settings[key] = getPrefFloat(key.c_str(), setting.floatDefault);
                 break;
         }
     }
 
-    preferences.end();
     return settings;
 }
 
 bool JsonSettings::fromJson(JsonDocument settings) {
-    preferences.begin(name, false);
-
     for (JsonPair kv : settings.as<JsonObject>()) {
         const char *key = kv.key().c_str();
-        JsonSetting setting = this->find(key);
+        auto it = this->map.find(key);
+        if (it == this->map.end()) {
+            continue;
+        }
+        JsonSetting setting = it->second;
 
         if (! setting.validate(kv.value().as<String>())) {
             lastValidationError = setting.getLastValidationError();
@@ -113,13 +162,17 @@ bool JsonSettings::fromJson(JsonDocument settings) {
 
         switch (setting.type) {
             case JsonSettingType::JST_INT_VECTOR:
-            case JsonSettingType::JST_STR: preferences.putString(key, kv.value().as<String>()); break;
-            case JsonSettingType::JST_INT: preferences.putInt(key, kv.value().as<int>()); break;
-            case JsonSettingType::JST_FLOAT: preferences.putFloat(key, kv.value().as<float>()); break;
+            case JsonSettingType::JST_STR:
+                putPrefString(key, kv.value().as<String>());
+                break;
+            case JsonSettingType::JST_INT:
+                putPrefInt(key, kv.value().as<int>());
+                break;
+            case JsonSettingType::JST_FLOAT:
+                putPrefFloat(key, kv.value().as<float>());
+                break;
         }
     }
-
-    preferences.end();
 
     return true;
 }

--- a/src/JsonSettings.h
+++ b/src/JsonSettings.h
@@ -15,11 +15,13 @@ class JsonSettings {
     int getInt(const char *key);
     float getFloat(const char *key);
     std::vector<int> getIntVector(const char *key);
+    std::vector<std::vector<int>> getIntMatrix(const char *key);
 
     void putString(const char *key, String value);
     void putInt(const char *key, int value);
     void putFloat(const char *key, float value);
     void putIntVector(const char *key, std::vector<int> value);
+    void putIntMatrix(const char *key, std::vector<std::vector<int>> value);
 
     JsonDocument toJson();
     bool fromJson(JsonDocument settings);

--- a/src/JsonSettings.h
+++ b/src/JsonSettings.h
@@ -26,9 +26,16 @@ class JsonSettings {
     bool reset();
 
     String getLastValidationError() { return lastValidationError; }
+    static String storageKey(const char *key);
     String getLastValidationKey() { return lastValidationKey; }
-
   private:
+    String getPrefString(const char *key, const String &def);
+    int getPrefInt(const char *key, int def);
+    float getPrefFloat(const char *key, float def);
+    void putPrefString(const char *key, const String &value);
+    void putPrefInt(const char *key, int value);
+    void putPrefFloat(const char *key, float value);
+
     const char *name;
     std::map<String, JsonSetting> map;
 

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -7,7 +7,7 @@
 SplitFlapDisplay::SplitFlapDisplay(JsonSettings &settings) : settings(settings) {}
 
 void SplitFlapDisplay::init() {
-    numModules = settings.getInt("moduleCount");
+    numModules = constrain(settings.getInt("moduleCount"), 1, MAX_MODULES);
     stepsPerRot = settings.getInt("stepsPerRot");
     displayOffset = settings.getInt("displayOffset");
     magnetPosition = settings.getInt("magnetPosition");
@@ -24,6 +24,14 @@ void SplitFlapDisplay::init() {
         moduleOffsets[i] = settingOffsets[i];
     }
 
+    std::vector<std::vector<int>> settingCharOffsets = settings.getIntMatrix("charOffsets");
+    for (int i = 0; i < numModules; i++) {
+        for (int j = 0; j < 48; j++) {
+            charOffsets[i][j] = (i < (int)settingCharOffsets.size() && j < (int)settingCharOffsets[i].size())
+                ? settingCharOffsets[i][j] : 0;
+        }
+    }
+
     Serial.print("Module Offsets: ");
     for (int i = 0; i < numModules; i++) {
         Serial.print(moduleOffsets[i]);
@@ -33,7 +41,7 @@ void SplitFlapDisplay::init() {
 
     for (uint8_t i = 0; i < numModules; i++) {
         modules[i] = SplitFlapModule(
-            moduleAddresses[i], stepsPerRot, moduleOffsets[i] + displayOffset, magnetPosition, charSetSize
+            moduleAddresses[i], stepsPerRot, moduleOffsets[i] + displayOffset, magnetPosition, charSetSize, charOffsets[i]
         );
     }
 
@@ -44,6 +52,30 @@ void SplitFlapDisplay::init() {
     Wire.setClock(400000);
 
     for (uint8_t i = 0; i < numModules; i++) {
+        modules[i].init();
+    }
+}
+
+void SplitFlapDisplay::reloadOffsets() {
+    displayOffset = settings.getInt("displayOffset");
+    
+    std::vector<int> settingOffsets = settings.getIntVector("moduleOffsets");
+    for (int i = 0; i < numModules; i++) {
+        moduleOffsets[i] = settingOffsets[i];
+    }
+
+    std::vector<std::vector<int>> settingCharOffsets = settings.getIntMatrix("charOffsets");
+    for (int i = 0; i < numModules; i++) {
+        for (int j = 0; j < 48; j++) {
+            charOffsets[i][j] = (i < (int)settingCharOffsets.size() && j < (int)settingCharOffsets[i].size())
+                ? settingCharOffsets[i][j] : 0;
+        }
+    }
+
+    for (uint8_t i = 0; i < numModules; i++) {
+        modules[i] = SplitFlapModule(
+            moduleAddresses[i], stepsPerRot, moduleOffsets[i] + displayOffset, magnetPosition, charSetSize, charOffsets[i]
+        );
         modules[i].init();
     }
 }

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -160,45 +160,172 @@ void SplitFlapDisplay::writeChar(char inputChar, float speed) {
     moveTo(targetPositions, speed);
 }
 
-void SplitFlapDisplay::writeString(String inputString, float speed, bool centering) {
-    String displayString = inputString.substring(0, numModules);
+void SplitFlapDisplay::writeString(
+    String inputString, float speed, bool centering, unsigned long scrollDelayMs
+) {
+    // Short path: fits in one frame — behave exactly as before.
+    if (inputString.length() <= numModules) {
+        displayChunk(inputString, speed, centering);
+        if (mqtt && mqtt->isConnected()) {
+            mqtt->publishState(inputString);
+        }
+        return;
+    }
+
+    // Long path: split into word-respecting chunks and display sequentially.
+    String chunks[MAX_MODULES * 4]; // generous upper bound for very long input
+    int chunkCount = 0;
+    splitIntoChunks(inputString, chunks, MAX_MODULES * 4, chunkCount);
+
+    Serial.printf(
+        "[scroll] input=%d chars, numModules=%d, chunks=%d\n",
+        inputString.length(), numModules, chunkCount
+    );
+
+    for (int i = 0; i < chunkCount; i++) {
+        displayChunk(chunks[i], speed, centering);
+        if (i < chunkCount - 1) {
+            delay(scrollDelayMs);
+        }
+    }
+
+    if (mqtt && mqtt->isConnected()) {
+        // Publish the original input so consumers see the full message, not
+        // just the final chunk on the display.
+        mqtt->publishState(inputString);
+    }
+}
+
+void SplitFlapDisplay::displayChunk(const String &chunk, float speed, bool centering) {
+    String displayString = chunk; // already <= numModules by construction
 
     if (centering) {
         int totalPadding = numModules - displayString.length();
         int paddingLeft = totalPadding / 2;
         int paddingRight = totalPadding - paddingLeft;
 
-        // Add padding to the left
         String result = "";
         for (int i = 0; i < paddingLeft; i++) {
             result += " ";
         }
-
-        // Add the original string
         result += displayString;
-
-        // Add padding to the right
         for (int i = 0; i < paddingRight; i++) {
             result += " ";
         }
         displayString = result;
     } else {                                          // pad blanks to end, if no centering
         while (displayString.length() < numModules) { // Pad with spaces
-            displayString += " ";                     // Padding with space
+            displayString += " ";
         }
     }
 
     int targetPositions[numModules];
-    // Iterate through the input string and process each character
     for (int i = 0; i < displayString.length(); i++) {
         char currentChar = displayString[i];
-        // Serial.println(currentChar);
         targetPositions[i] = modules[i].getCharPosition(currentChar);
     }
     moveTo(targetPositions, speed);
+}
 
-    if (mqtt && mqtt->isConnected()) {
-        mqtt->publishState(displayString);
+void SplitFlapDisplay::splitIntoChunks(
+    const String &input, String chunks[], int maxChunks, int &outCount
+) {
+    outCount = 0;
+
+    // Normalize: collapse internal whitespace to single spaces and trim ends.
+    // Without this, runs of spaces create invisible word boundaries and we
+    // produce empty-looking chunks.
+    String s = "";
+    bool lastWasSpace = true; // leading whitespace treated like a space
+    for (unsigned int i = 0; i < input.length(); i++) {
+        char c = input[i];
+        bool isSpace = (c == ' ' || c == '\t' || c == '\n' || c == '\r');
+        if (isSpace) {
+            if (! lastWasSpace) {
+                s += ' ';
+                lastWasSpace = true;
+            }
+        } else {
+            s += c;
+            lastWasSpace = false;
+        }
+    }
+    while (s.length() > 0 && s[s.length() - 1] == ' ') {
+        s.remove(s.length() - 1);
+    }
+
+    if (s.length() == 0) {
+        chunks[0] = "";
+        outCount = 1;
+        return;
+    }
+
+    // Greedy word-pack: walk words, append to current chunk while it fits.
+    // Word boundaries only — never split a word that can fit on its own.
+    // Oversized words (longer than numModules) are split mid-word, which is
+    // the only feasible option since they physically can't be displayed whole.
+    // The tail of an oversized split is left in `current` so subsequent
+    // words can pack with it.
+    String current = "";
+    int idx = 0;
+    while (idx < (int) s.length() && outCount < maxChunks) {
+        // Skip leading spaces to find the next word.
+        int wordStart = idx;
+        while (wordStart < (int) s.length() && s[wordStart] == ' ') {
+            wordStart++;
+        }
+        if (wordStart >= (int) s.length()) {
+            break;
+        }
+        int wordEnd = wordStart;
+        while (wordEnd < (int) s.length() && s[wordEnd] != ' ') {
+            wordEnd++;
+        }
+        int wordLen = wordEnd - wordStart;
+
+        int neededSep = (current.length() > 0) ? 1 : 0;
+        int wouldNeed = (int) current.length() + neededSep + wordLen;
+
+        if (wouldNeed <= numModules) {
+            // Word fits (with separator if `current` already has content).
+            if (neededSep) {
+                current += ' ';
+            }
+            current += s.substring(wordStart, wordEnd);
+            idx = wordEnd; // consume the word
+        } else if (current.length() > 0) {
+            // Word doesn't fit alongside what's in `current`. Flush `current`
+            // (right-padded to numModules) and retry this word in a fresh
+            // chunk by rewinding idx back to wordStart.
+            while ((int) current.length() < numModules) {
+                current += ' ';
+            }
+            chunks[outCount++] = current;
+            current = "";
+            idx = wordStart;
+        } else {
+            // `current` is empty and the single word is still too big.
+            // Oversized-word edge case: split mid-word into numModules-sized
+            // pieces. Emit full-size pieces, then leave the remainder as
+            // the start of `current` so following words can pack with it.
+            int remaining = wordLen;
+            int pos = wordStart;
+            while (remaining > numModules && outCount < maxChunks) {
+                chunks[outCount++] = s.substring(pos, pos + numModules);
+                pos += numModules;
+                remaining -= numModules;
+            }
+            current = s.substring(pos, pos + remaining);
+            idx = wordEnd; // past the oversized word
+        }
+    }
+
+    // Flush final chunk.
+    if (current.length() > 0 && outCount < maxChunks) {
+        while ((int) current.length() < numModules) {
+            current += ' ';
+        }
+        chunks[outCount++] = current;
     }
 }
 

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -162,12 +162,12 @@ void SplitFlapDisplay::writeChar(char inputChar, float speed) {
 
 void SplitFlapDisplay::writeString(
     String inputString, float speed, bool centering, unsigned long scrollDelayMs,
-    int scrollRepeatCount
+    int scrollRepeatCount, bool publishState
 ) {
     // Short path: fits in one frame — behave exactly as before.
     if (inputString.length() <= numModules) {
         displayChunk(inputString, speed, centering);
-        if (mqtt && mqtt->isConnected()) {
+        if (publishState && mqtt && mqtt->isConnected()) {
             mqtt->publishState(inputString);
         }
         return;
@@ -202,7 +202,7 @@ void SplitFlapDisplay::writeString(
         }
     }
 
-    if (mqtt && mqtt->isConnected()) {
+    if (publishState && mqtt && mqtt->isConnected()) {
         // Publish the original input so consumers see the full message, not
         // just the final chunk on the display.
         mqtt->publishState(inputString);

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -161,7 +161,8 @@ void SplitFlapDisplay::writeChar(char inputChar, float speed) {
 }
 
 void SplitFlapDisplay::writeString(
-    String inputString, float speed, bool centering, unsigned long scrollDelayMs
+    String inputString, float speed, bool centering, unsigned long scrollDelayMs,
+    int scrollRepeatCount
 ) {
     // Short path: fits in one frame — behave exactly as before.
     if (inputString.length() <= numModules) {
@@ -172,20 +173,32 @@ void SplitFlapDisplay::writeString(
         return;
     }
 
-    // Long path: split into word-respecting chunks and display sequentially.
+    // Long path: split into word-respecting chunks and display sequentially,
+    // repeating the full chunk sequence scrollRepeatCount times end-to-end.
+    // Clamp the count to a sane range so a misconfigured value (0, negative,
+    // or absurdly large) can't lock up the display loop.
+    int repeats = constrain(
+        scrollRepeatCount, MIN_SCROLL_REPEAT_COUNT, MAX_SCROLL_REPEAT_COUNT
+    );
+
     String chunks[MAX_MODULES * 4]; // generous upper bound for very long input
     int chunkCount = 0;
     splitIntoChunks(inputString, chunks, MAX_MODULES * 4, chunkCount);
 
     Serial.printf(
-        "[scroll] input=%d chars, numModules=%d, chunks=%d\n",
-        inputString.length(), numModules, chunkCount
+        "[scroll] input=%d chars, numModules=%d, chunks=%d, repeats=%d\n",
+        inputString.length(), numModules, chunkCount, repeats
     );
 
-    for (int i = 0; i < chunkCount; i++) {
-        displayChunk(chunks[i], speed, centering);
-        if (i < chunkCount - 1) {
-            delay(scrollDelayMs);
+    for (int r = 0; r < repeats; r++) {
+        for (int i = 0; i < chunkCount; i++) {
+            displayChunk(chunks[i], speed, centering);
+            // Pause between chunks within a pass. We also pause between the
+            // last chunk of pass r and the first chunk of pass r+1 so the
+            // reader gets a clear "wrap" — same delay as intra-pass is fine.
+            if (i < chunkCount - 1 || r < repeats - 1) {
+                delay(scrollDelayMs);
+            }
         }
     }
 

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -73,10 +73,8 @@ void SplitFlapDisplay::reloadOffsets() {
     }
 
     for (uint8_t i = 0; i < numModules; i++) {
-        modules[i] = SplitFlapModule(
-            moduleAddresses[i], stepsPerRot, moduleOffsets[i] + displayOffset, magnetPosition, charSetSize, charOffsets[i]
-        );
-        modules[i].init();
+        int newMagnetOffset = magnetPosition + moduleOffsets[i] + displayOffset;
+        modules[i].updateOffsets(charOffsets[i], newMagnetOffset);
     }
 }
 

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -3,8 +3,9 @@
 #include "JsonSettings.h"
 #include "SplitFlapModule.h"
 #include "SplitFlapMqtt.h"
+#include "SplitFlapMotorScheduler.h"
 
-SplitFlapDisplay::SplitFlapDisplay(JsonSettings &settings) : settings(settings) {
+SplitFlapDisplay::SplitFlapDisplay(JsonSettings &settings) : settings(settings), maxConcurrentMotors(-1) {
     for (int i = 0; i < MAX_MODULES; i++) {
         lastDisplayedChar[i] = ' ';
     }
@@ -124,6 +125,7 @@ void SplitFlapDisplay::reloadOffsets() {
 
 void SplitFlapDisplay::homeAffectedModules(bool affected[], float speed) {
     Serial.println("Homing affected modules");
+    maxConcurrentMotors = constrain(settings.getInt("maxConcurrentMotors"), 1, MAX_MODULES);
     int targetPositions[numModules];
     for (int i = 0; i < numModules; i++) {
         if (affected[i]) {
@@ -132,7 +134,6 @@ void SplitFlapDisplay::homeAffectedModules(bool affected[], float speed) {
             targetPositions[i] = modules[i].getPosition();
         }
     }
-    startMotors();
     moveTo(targetPositions, speed, false);
 
     for (int i = 0; i < numModules; i++) {
@@ -146,6 +147,7 @@ void SplitFlapDisplay::homeAffectedModules(bool affected[], float speed) {
 }
 
 void SplitFlapDisplay::testAll() {
+    maxConcurrentMotors = -1; // unlimited — test/display moves are short
     char testChars[37] = {' ', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
                           'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
     int numChars = sizeof(testChars) / sizeof(testChars[0]);
@@ -169,6 +171,7 @@ void SplitFlapDisplay::testAll() {
 }
 
 void SplitFlapDisplay::testRandom(float speed) {
+    maxConcurrentMotors = -1; // unlimited — test/display moves are short
     char testChars[37] = {' ', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
                           'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
 
@@ -186,6 +189,7 @@ void SplitFlapDisplay::testRandom(float speed) {
 }
 
 void SplitFlapDisplay::testCount() {
+    maxConcurrentMotors = -1; // unlimited — test/display moves are short
     int count = 0;
     int maxCount = pow(10, numModules);
     char targetChar;
@@ -208,11 +212,11 @@ void SplitFlapDisplay::testCount() {
 
 void SplitFlapDisplay::home(float speed) {
     Serial.println("Homing");
+    maxConcurrentMotors = constrain(settings.getInt("maxConcurrentMotors"), 1, MAX_MODULES);
     int targetPositions[numModules];
     for (int i = 0; i < numModules; i++) {
         targetPositions[i] = (modules[i].getPosition() - 1 + stepsPerRot) % stepsPerRot;
     }
-    startMotors();
     moveTo(targetPositions, speed, false);
     char homeChar = ' ';
     int charPosition;
@@ -225,32 +229,36 @@ void SplitFlapDisplay::home(float speed) {
 
 void SplitFlapDisplay::homeToString(String homeString, float speed, bool centering) {
     Serial.println("Homing");
+    maxConcurrentMotors = constrain(settings.getInt("maxConcurrentMotors"), 1, MAX_MODULES);
     int targetPositions[numModules];
     for (int i = 0; i < numModules; i++) {
         targetPositions[i] = (modules[i].getPosition() - 1 + stepsPerRot) % stepsPerRot;
     }
-    startMotors();
     moveTo(targetPositions, speed, false);
-    writeString(homeString, speed, centering);
+    // Reposition straight to the target string instead of going through
+    // writeString(): writeString resets maxConcurrentMotors to unlimited,
+    // which would defeat the homing concurrency cap on the reposition move.
+    displayChunk(homeString, speed, centering);
 }
 
 void SplitFlapDisplay::homeToChar(char homeChar, float speed) {
     Serial.println("Homing");
+    maxConcurrentMotors = constrain(settings.getInt("maxConcurrentMotors"), 1, MAX_MODULES);
     int targetPositions[numModules];
     for (int i = 0; i < numModules; i++) {
         targetPositions[i] = (modules[i].getPosition() - 1 + stepsPerRot) % stepsPerRot;
     }
-    startMotors();
     moveTo(targetPositions, speed, false);
 
     for (int i = 0; i < numModules; i++) {
         targetPositions[i] = modules[i].getCharPosition(homeChar);
         lastDisplayedChar[i] = homeChar;
     }
-    moveTo(targetPositions, true, speed);
+    moveTo(targetPositions, speed, true);
 }
 
 void SplitFlapDisplay::writeChar(char inputChar, float speed) {
+    maxConcurrentMotors = -1; // unlimited — normal display writes stay fast
     int targetPositions[numModules];
     // Iterate through the input string and process each character
     for (int i = 0; i < numModules; i++) {
@@ -264,6 +272,8 @@ void SplitFlapDisplay::writeString(
     String inputString, float speed, bool centering, unsigned long scrollDelayMs,
     int scrollRepeatCount, bool publishState
 ) {
+    // Normal display writes are not concurrency-capped (homing is).
+    maxConcurrentMotors = -1;
     // Short path: fits in one frame — behave exactly as before.
     if (inputString.length() <= numModules) {
         displayChunk(inputString, speed, centering);
@@ -457,11 +467,17 @@ void SplitFlapDisplay::moveTo(int targetPositions[], float speed, bool releaseMo
     int startStopDelay = 200; // time to wait to let motor realign itself to
     // magnetic field on stop and start
 
-    bool resetLatches[numModules] = {}; // Initialize to false //start with latch on to prevent case where the
+    bool resetLatches[numModules] = {};          // start with latch on to prevent case where the
     // motion starts with the magnet over the sensor
-    bool needsStepping[numModules] = {};             // Initialize to false; //modules that still require moving
-    unsigned long lastStepTimes[numModules] = {};    // Initialize to false; //track when each module was last stepped
+    bool needsStepping[numModules] = {};         // modules that still require moving
+    bool motorsOn[numModules] = {};              // modules whose coils are currently energized
+    unsigned long lastStepTimes[numModules] = {}; // track when each module was last stepped
     unsigned long lastSensorCheckTime = currentTime; // track when we last read all the hall effect sensors
+
+    // Concurrency cap: limits how many motors are energized at once. Homing
+    // paths set this from the "maxConcurrentMotors" setting (>= 1); normal
+    // message writes set it to -1 (unlimited, all motors start immediately).
+    SplitFlapMotorScheduler scheduler(numModules, maxConcurrentMotors);
 
     for (int i = 0; i < numModules; i++) {
         targetPositions[i] = constrain(
@@ -471,27 +487,58 @@ void SplitFlapDisplay::moveTo(int targetPositions[], float speed, bool releaseMo
         ); // Constrain to avoid errors with incorrect inputs
         resetLatches[i] = true;
         lastStepTimes[i] = currentTime;
-        if (modules[i].getPosition() != targetPositions[i]) {
-            needsStepping[i] = true;
-        } else {
-            needsStepping[i] = false;
-        }
+        needsStepping[i] = (modules[i].getPosition() != targetPositions[i]);
     }
 
-    startMotors(); // not sure if this helps or not, likely that it does not based
-    // on testing
-    delay(startStopDelay); // give the motor time to align to magnetic field
+    // Previously this energized EVERY module (even ones that don't need to
+    // move) and left them all on until the end of the move. Now each motor
+    // is energized only when it has a scheduling slot, and released the
+    // instant it reaches its target, so the instantaneous coil current is
+    // bounded by the cap instead of the full module count.
+    if (maxConcurrentMotors < 0) {
+        startMotors();
+        delay(startStopDelay); // give the motor time to align to magnetic field
+    }
 
     bool isFinished = checkAllFalse(needsStepping, numModules);
     while (! isFinished) {
         currentTime = micros();
         for (int i = 0; i < numModules; i++) {
-            if (((currentTime - lastStepTimes[i]) > timePerStep) && needsStepping[i]) {
+            if (! needsStepping[i]) {
+                continue;
+            }
+
+            // Grant a slot to motors that haven't started yet, subject to
+            // the concurrency cap. Motors that can't get a slot simply wait
+            // for the next loop iteration (a slot frees when another motor
+            // reaches its target).
+            if (! motorsOn[i]) {
+                if (! scheduler.start(i)) {
+                    continue; // cap reached — try again next tick
+                }
+                motorsOn[i] = true;
+                if (maxConcurrentMotors >= 0) {
+                    // Capped (homing): this motor got its slot mid-loop, so
+                    // give it the same coil-align settle time the uncapped
+                    // path's global delay above provides before its first
+                    // step. The uncapped path leaves lastStepTimes at its
+                    // initial value — motors already settled during the
+                    // global delay, preserving the original step timing.
+                    lastStepTimes[i] = currentTime + startStopDelay * 1000;
+                }
+            }
+
+            if ((currentTime - lastStepTimes[i]) > timePerStep) {
                 modules[i].step();
                 lastStepTimes[i] = micros();
                 if (modules[i].getPosition() == targetPositions[i]) { // this module is not in the correct position,
                     // requires stepping
                     needsStepping[i] = false;
+                    // Release this motor's coils immediately instead of
+                    // holding it until the slowest module finishes.
+                    modules[i].stop();
+                    motorsOn[i] = false;
+                    scheduler.finish(i);
                 }
             }
         }
@@ -499,7 +546,7 @@ void SplitFlapDisplay::moveTo(int targetPositions[], float speed, bool releaseMo
         if ((currentTime - lastSensorCheckTime) > checkIntervalUs) { // check hall effect sensor every checkIntervalMs
             // check every modules sensor
             for (int i = 0; i < numModules; i++) {
-                if (needsStepping[i] &&
+                if (needsStepping[i] && motorsOn[i] &&
                     (modules[i].readHallEffectSensor() == true
                     )) { // only check sensors where the module is still moving
                     if (! resetLatches[i]) {

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -4,7 +4,11 @@
 #include "SplitFlapModule.h"
 #include "SplitFlapMqtt.h"
 
-SplitFlapDisplay::SplitFlapDisplay(JsonSettings &settings) : settings(settings) {}
+SplitFlapDisplay::SplitFlapDisplay(JsonSettings &settings) : settings(settings) {
+    for (int i = 0; i < MAX_MODULES; i++) {
+        lastDisplayedChar[i] = ' ';
+    }
+}
 
 void SplitFlapDisplay::init() {
     numModules = constrain(settings.getInt("moduleCount"), 1, MAX_MODULES);
@@ -57,8 +61,18 @@ void SplitFlapDisplay::init() {
 }
 
 void SplitFlapDisplay::reloadOffsets() {
+    int oldDisplayOffset = displayOffset;
+    int oldModuleOffsets[MAX_MODULES];
+    int oldCharOffsets[MAX_MODULES][48];
+    for (int i = 0; i < numModules; i++) {
+        oldModuleOffsets[i] = moduleOffsets[i];
+        for (int j = 0; j < 48; j++) {
+            oldCharOffsets[i][j] = charOffsets[i][j];
+        }
+    }
+
     displayOffset = settings.getInt("displayOffset");
-    
+
     std::vector<int> settingOffsets = settings.getIntVector("moduleOffsets");
     for (int i = 0; i < numModules; i++) {
         moduleOffsets[i] = settingOffsets[i];
@@ -72,10 +86,63 @@ void SplitFlapDisplay::reloadOffsets() {
         }
     }
 
+    bool affected[MAX_MODULES] = {};
+    bool anyAffected = false;
+
+    if (oldDisplayOffset != displayOffset) {
+        for (int i = 0; i < numModules; i++) {
+            affected[i] = true;
+        }
+        anyAffected = true;
+    } else {
+        for (int i = 0; i < numModules; i++) {
+            bool moduleChanged = (oldModuleOffsets[i] != moduleOffsets[i]);
+            if (! moduleChanged) {
+                for (int j = 0; j < 48; j++) {
+                    if (oldCharOffsets[i][j] != charOffsets[i][j]) {
+                        moduleChanged = true;
+                        break;
+                    }
+                }
+            }
+            affected[i] = moduleChanged;
+            if (moduleChanged) {
+                anyAffected = true;
+            }
+        }
+    }
+
     for (uint8_t i = 0; i < numModules; i++) {
         int newMagnetOffset = magnetPosition + moduleOffsets[i] + displayOffset;
         modules[i].updateOffsets(charOffsets[i], newMagnetOffset);
     }
+
+    if (anyAffected) {
+        homeAffectedModules(affected);
+    }
+}
+
+void SplitFlapDisplay::homeAffectedModules(bool affected[], float speed) {
+    Serial.println("Homing affected modules");
+    int targetPositions[numModules];
+    for (int i = 0; i < numModules; i++) {
+        if (affected[i]) {
+            targetPositions[i] = (modules[i].getPosition() - 1 + stepsPerRot) % stepsPerRot;
+        } else {
+            targetPositions[i] = modules[i].getPosition();
+        }
+    }
+    startMotors();
+    moveTo(targetPositions, speed, false);
+
+    for (int i = 0; i < numModules; i++) {
+        if (affected[i]) {
+            targetPositions[i] = modules[i].getCharPosition(lastDisplayedChar[i]);
+        } else {
+            targetPositions[i] = modules[i].getPosition();
+        }
+    }
+    moveTo(targetPositions, speed);
 }
 
 void SplitFlapDisplay::testAll() {
@@ -151,6 +218,7 @@ void SplitFlapDisplay::home(float speed) {
     int charPosition;
     for (int i = 0; i < numModules; i++) {
         targetPositions[i] = modules[i].getCharPosition(homeChar);
+        lastDisplayedChar[i] = homeChar;
     }
     moveTo(targetPositions, speed);
 }
@@ -177,6 +245,7 @@ void SplitFlapDisplay::homeToChar(char homeChar, float speed) {
 
     for (int i = 0; i < numModules; i++) {
         targetPositions[i] = modules[i].getCharPosition(homeChar);
+        lastDisplayedChar[i] = homeChar;
     }
     moveTo(targetPositions, true, speed);
 }
@@ -186,6 +255,7 @@ void SplitFlapDisplay::writeChar(char inputChar, float speed) {
     // Iterate through the input string and process each character
     for (int i = 0; i < numModules; i++) {
         targetPositions[i] = modules[i].getCharPosition(inputChar);
+        lastDisplayedChar[i] = inputChar;
     }
     moveTo(targetPositions, speed);
 }
@@ -266,6 +336,7 @@ void SplitFlapDisplay::displayChunk(const String &chunk, float speed, bool cente
     for (int i = 0; i < displayString.length(); i++) {
         char currentChar = displayString[i];
         targetPositions[i] = modules[i].getCharPosition(currentChar);
+        lastDisplayedChar[i] = currentChar;
     }
     moveTo(targetPositions, speed);
 }

--- a/src/SplitFlapDisplay.h
+++ b/src/SplitFlapDisplay.h
@@ -19,6 +19,7 @@ class SplitFlapDisplay {
     SplitFlapDisplay(JsonSettings &settings);
 
     void init();
+    void reloadOffsets();
     void writeString(
         String inputString, float speed = MAX_RPM, bool centering = true,
         unsigned long scrollDelayMs = DEFAULT_SCROLL_DELAY_MS,
@@ -68,6 +69,7 @@ class SplitFlapDisplay {
     uint8_t moduleAddresses[MAX_MODULES];
     SplitFlapModule modules[MAX_MODULES];
     int moduleOffsets[MAX_MODULES];
+    int charOffsets[MAX_MODULES][48];
     int displayOffset;
 
     float maxVel;       // Max Velocity In RPM

--- a/src/SplitFlapDisplay.h
+++ b/src/SplitFlapDisplay.h
@@ -7,6 +7,7 @@
 
 #define MAX_MODULES 8 // for memory allocation, update if more modules
 #define MAX_RPM 15.0f
+#define DEFAULT_SCROLL_DELAY_MS 1500 // pause between chunks when scrolling
 
 class SplitFlapMqtt;
 
@@ -16,9 +17,10 @@ class SplitFlapDisplay {
 
     void init();
     void writeString(
-        String inputString, float speed = MAX_RPM,
-        bool centering = true
-    );                                     // Move all modules at once to show a specific string
+        String inputString, float speed = MAX_RPM, bool centering = true,
+        unsigned long scrollDelayMs = DEFAULT_SCROLL_DELAY_MS
+    ); // Move all modules at once to show a specific string. If longer than
+       // numModules, splits on word boundaries and shows chunks sequentially.
     void writeChar(char inputChar,
                    float speed = MAX_RPM); // sets all modules to a single char
     void moveTo(int targetPositions[], float speed = MAX_RPM, bool releaseMotors = true);
@@ -42,6 +44,19 @@ class SplitFlapDisplay {
     bool checkAllFalse(bool array[], int size);
     void stopMotors();
     void startMotors();
+
+    // Split a string into chunks of <= numModules chars, breaking only at word
+    // boundaries. A word longer than numModules is split mid-word (no other
+    // option — it physically can't fit whole).
+    void splitIntoChunks(
+        const String &input, String chunks[], int maxChunks, int &outCount
+    );
+
+    // Display one already-sized chunk using the same center/pad logic as
+    // writeString, but without truncation (chunk is already <= numModules).
+    void displayChunk(
+        const String &chunk, float speed = MAX_RPM, bool centering = true
+    );
 
     int numModules;
     uint8_t moduleAddresses[MAX_MODULES];

--- a/src/SplitFlapDisplay.h
+++ b/src/SplitFlapDisplay.h
@@ -7,7 +7,10 @@
 
 #define MAX_MODULES 8 // for memory allocation, update if more modules
 #define MAX_RPM 15.0f
-#define DEFAULT_SCROLL_DELAY_MS 1500 // pause between chunks when scrolling
+#define DEFAULT_SCROLL_DELAY_MS 1500      // pause between chunks when scrolling
+#define DEFAULT_SCROLL_REPEAT_COUNT 2    // how many times a long message is shown end-to-end
+#define MIN_SCROLL_REPEAT_COUNT 1        // floor for scrollRepeatCount (1 = no repeat)
+#define MAX_SCROLL_REPEAT_COUNT 99       // ceiling — guards against runaway looping
 
 class SplitFlapMqtt;
 
@@ -18,9 +21,11 @@ class SplitFlapDisplay {
     void init();
     void writeString(
         String inputString, float speed = MAX_RPM, bool centering = true,
-        unsigned long scrollDelayMs = DEFAULT_SCROLL_DELAY_MS
+        unsigned long scrollDelayMs = DEFAULT_SCROLL_DELAY_MS,
+        int scrollRepeatCount = DEFAULT_SCROLL_REPEAT_COUNT
     ); // Move all modules at once to show a specific string. If longer than
-       // numModules, splits on word boundaries and shows chunks sequentially.
+       // numModules, splits on word boundaries and shows chunks sequentially,
+       // repeating the full chunk sequence scrollRepeatCount times total.
     void writeChar(char inputChar,
                    float speed = MAX_RPM); // sets all modules to a single char
     void moveTo(int targetPositions[], float speed = MAX_RPM, bool releaseMotors = true);

--- a/src/SplitFlapDisplay.h
+++ b/src/SplitFlapDisplay.h
@@ -22,7 +22,8 @@ class SplitFlapDisplay {
     void writeString(
         String inputString, float speed = MAX_RPM, bool centering = true,
         unsigned long scrollDelayMs = DEFAULT_SCROLL_DELAY_MS,
-        int scrollRepeatCount = DEFAULT_SCROLL_REPEAT_COUNT
+        int scrollRepeatCount = DEFAULT_SCROLL_REPEAT_COUNT,
+        bool publishState = true
     ); // Move all modules at once to show a specific string. If longer than
        // numModules, splits on word boundaries and shows chunks sequentially,
        // repeating the full chunk sequence scrollRepeatCount times total.

--- a/src/SplitFlapDisplay.h
+++ b/src/SplitFlapDisplay.h
@@ -20,6 +20,7 @@ class SplitFlapDisplay {
 
     void init();
     void reloadOffsets();
+    void homeAffectedModules(bool affected[], float speed = MAX_RPM);
     void writeString(
         String inputString, float speed = MAX_RPM, bool centering = true,
         unsigned long scrollDelayMs = DEFAULT_SCROLL_DELAY_MS,
@@ -71,6 +72,9 @@ class SplitFlapDisplay {
     int moduleOffsets[MAX_MODULES];
     int charOffsets[MAX_MODULES][48];
     int displayOffset;
+    char lastDisplayedChar[MAX_MODULES]; // last char each module was asked to
+                                         // show; used by reloadOffsets to
+                                         // reposition after a home
 
     float maxVel;       // Max Velocity In RPM
     int charSetSize;    // 37 for standard, 48 for extended

--- a/src/SplitFlapDisplay.h
+++ b/src/SplitFlapDisplay.h
@@ -76,6 +76,12 @@ class SplitFlapDisplay {
                                          // show; used by reloadOffsets to
                                          // reposition after a home
 
+    // Concurrency cap for moveTo(): number of motors allowed to be
+    // energized at the same time. < 0 = unlimited (normal message writes).
+    // Homing paths set this from the "maxConcurrentMotors" setting so the
+    // boot homing peak stays bounded on large displays.
+    int maxConcurrentMotors;
+
     float maxVel;       // Max Velocity In RPM
     int charSetSize;    // 37 for standard, 48 for extended
     int stepsPerRot;    // number of motor steps per full rotation of character

--- a/src/SplitFlapDisplay.ino
+++ b/src/SplitFlapDisplay.ino
@@ -40,6 +40,9 @@ JsonSettings settings = JsonSettings("config", {
     {"stepsPerRot", JsonSetting(2048)},
     {"maxVel", JsonSetting(15.0f)},
     {"charset", JsonSetting(37)},
+    // Scroll Settings (only applies to messages longer than numModules)
+    {"scrollDelayMs", JsonSetting(1500)},
+    {"scrollRepeatCount", JsonSetting(2)},
     // Operational States
     {"mode", JsonSetting(0)}
 });
@@ -117,7 +120,11 @@ void loop() {
 void singleInputMode() {
     String userInput = webServer.getInputString();
     if (userInput != webServer.getWrittenString()) {
-        display.writeString(userInput, MAX_RPM, webServer.getCentering());
+        display.writeString(
+            userInput, MAX_RPM, webServer.getCentering(),
+            settings.getInt("scrollDelayMs"),
+            settings.getInt("scrollRepeatCount")
+        );
         webServer.setWrittenString(userInput);
     }
 }
@@ -128,7 +135,11 @@ void multiInputMode() {
         String userInput = webServer.getMultiInputString();
         String currWord = extractFromCSV(userInput, webServer.getMultiWordCurrentIndex());
         if (currWord != webServer.getWrittenString()) {
-            display.writeString(currWord, MAX_RPM, webServer.getCentering());
+            display.writeString(
+                currWord, MAX_RPM, webServer.getCentering(),
+                settings.getInt("scrollDelayMs"),
+                settings.getInt("scrollRepeatCount")
+            );
             webServer.setWrittenString(currWord);
         }
         webServer.setLastSwitchMultiTime(millis());

--- a/src/SplitFlapDisplay.ino
+++ b/src/SplitFlapDisplay.ino
@@ -6,6 +6,7 @@
 // Enjoy :)
 #include "JsonSettings.h"
 #include "SplitFlapDisplay.h"
+#include "SplitFlapEspNow.h"
 #include "SplitFlapMqtt.h"
 #include "SplitFlapWebServer.h"
 
@@ -43,6 +44,10 @@ JsonSettings settings = JsonSettings("config", {
     // Scroll Settings (only applies to messages longer than numModules)
     {"scrollDelayMs", JsonSetting(1500)},
     {"scrollRepeatCount", JsonSetting(2)},
+    // Multi-display master settings
+    {"masterGroupCount", JsonSetting(1)},
+    {"masterGroupModuleCounts", JsonSetting({8, 8, 8, 8, 8, 8})},
+    {"masterGroupMacs", JsonSetting(",,,,,")},
     // Operational States
     {"mode", JsonSetting(0)}
 });
@@ -50,51 +55,91 @@ JsonSettings settings = JsonSettings("config", {
 
 WiFiClient wifiClient;
 SplitFlapDisplay display(settings);
+SplitFlapEspNow *splitflapEspNow = nullptr;
 SplitFlapWebServer webServer(settings);
 SplitFlapMqtt splitflapMqtt(settings, wifiClient);
+
+bool isMultiDisplayMasterEnabled() {
+    return settings.getInt("masterGroupCount") > 1;
+}
+
+SplitFlapEspNow *getSplitFlapEspNow() {
+    if (! splitflapEspNow) {
+        splitflapEspNow = new SplitFlapEspNow(settings, display);
+    }
+    return splitflapEspNow;
+}
 
 void setup() {
     // put your setup code here, to run once:
     Serial.begin(SERIAL_SPEED);
+    Serial.println("[boot] serial ready");
+    Serial.flush();
 
 #ifdef STARTUP_DELAY
     delay(STARTUP_DELAY);
 #endif
 
     Serial.println("Init Web Server");
+    Serial.flush();
     webServer.init();
+    Serial.println("[boot] web server init complete");
+    Serial.flush();
 
     if (! webServer.connectToWifi()) {
+        Serial.println("[boot] wifi unavailable, starting access point");
+        Serial.flush();
         webServer.startAccessPoint();
         webServer.enableOta();
         webServer.startMDNS();
         webServer.startWebServer();
+        Serial.println("[boot] services started in access point mode");
+        Serial.flush();
 
         display.init();
+        Serial.println("[boot] display init complete");
+        Serial.flush();
         display.homeToString("");
+        Serial.println("[boot] display homed");
+        Serial.flush();
 
         if (display.getNumModules() == 8) {
             display.writeString("Wifi Err");
         } else {
             display.writeChar('X');
         }
+        Serial.println("[boot] setup complete in access point mode");
+        Serial.flush();
     } else {
+        Serial.println("[boot] wifi connected");
+        Serial.flush();
         webServer.enableOta();
         webServer.startMDNS();
         webServer.startWebServer();
+        Serial.println("[boot] network services started");
+        Serial.flush();
 
         display.init();
+        Serial.println("[boot] display init complete");
+        Serial.flush();
         splitflapMqtt.setup();
         splitflapMqtt.setDisplay(&display);
         display.setMqtt(&splitflapMqtt);
+        Serial.println("[boot] mqtt setup complete");
+        Serial.flush();
 
         display.homeToString("OK");
         delay(250);
         display.writeString("");
+        Serial.println("[boot] setup complete in wifi mode");
+        Serial.flush();
     }
 }
 
 void loop() {
+    if (splitflapEspNow) {
+        splitflapEspNow->loop();
+    }
     splitflapMqtt.loop();
 
     // check what mode the display is in, this value is updated by the web server
@@ -105,6 +150,7 @@ void loop() {
         case 3: timeMode(); break;
         case 4: break;
         case 5: randomTest(); break;
+        case ESP_NOW_REMOTE_MODE: break;
         default: break;
     }
 
@@ -120,26 +166,52 @@ void loop() {
 void singleInputMode() {
     String userInput = webServer.getInputString();
     if (userInput != webServer.getWrittenString()) {
-        display.writeString(
-            userInput, MAX_RPM, webServer.getCentering(),
-            settings.getInt("scrollDelayMs"),
-            settings.getInt("scrollRepeatCount")
-        );
+        if (isMultiDisplayMasterEnabled()) {
+            getSplitFlapEspNow()->distributeMessage(
+                userInput, webServer.getCentering(),
+                settings.getInt("scrollDelayMs"),
+                settings.getInt("scrollRepeatCount")
+            );
+            if (splitflapMqtt.isConnected()) {
+                splitflapMqtt.publishState(userInput);
+            }
+        } else {
+            display.writeString(
+                userInput, MAX_RPM, webServer.getCentering(),
+                settings.getInt("scrollDelayMs"),
+                settings.getInt("scrollRepeatCount")
+            );
+        }
         webServer.setWrittenString(userInput);
     }
 }
 
 void multiInputMode() {
+    if (webServer.getNumMultiWords() <= 0) {
+        return;
+    }
+
     if (millis() - webServer.getLastSwitchMultiTime() > webServer.getMultiWordDelay()) {
         // get user input, extract correct word from index using webserver counter, and display
         String userInput = webServer.getMultiInputString();
         String currWord = extractFromCSV(userInput, webServer.getMultiWordCurrentIndex());
         if (currWord != webServer.getWrittenString()) {
-            display.writeString(
-                currWord, MAX_RPM, webServer.getCentering(),
-                settings.getInt("scrollDelayMs"),
-                settings.getInt("scrollRepeatCount")
-            );
+            if (isMultiDisplayMasterEnabled()) {
+                getSplitFlapEspNow()->distributeMessage(
+                    currWord, webServer.getCentering(),
+                    settings.getInt("scrollDelayMs"),
+                    settings.getInt("scrollRepeatCount")
+                );
+                if (splitflapMqtt.isConnected()) {
+                    splitflapMqtt.publishState(currWord);
+                }
+            } else {
+                display.writeString(
+                    currWord, MAX_RPM, webServer.getCentering(),
+                    settings.getInt("scrollDelayMs"),
+                    settings.getInt("scrollRepeatCount")
+                );
+            }
             webServer.setWrittenString(currWord);
         }
         webServer.setLastSwitchMultiTime(millis());

--- a/src/SplitFlapDisplay.ino
+++ b/src/SplitFlapDisplay.ino
@@ -99,6 +99,12 @@ void setup() {
         display.init();
         Serial.println("[boot] display init complete");
         Serial.flush();
+        if (getSplitFlapEspNow()->init()) {
+            Serial.println("[boot] esp-now initialized successfully");
+        } else {
+            Serial.println("[boot] esp-now initialization failed");
+        }
+        Serial.flush();
         display.homeToString("");
         Serial.println("[boot] display homed");
         Serial.flush();
@@ -122,8 +128,15 @@ void setup() {
         display.init();
         Serial.println("[boot] display init complete");
         Serial.flush();
+        if (getSplitFlapEspNow()->init()) {
+            Serial.println("[boot] esp-now initialized successfully");
+        } else {
+            Serial.println("[boot] esp-now initialization failed");
+        }
+        Serial.flush();
         splitflapMqtt.setup();
         splitflapMqtt.setDisplay(&display);
+        splitflapMqtt.setEspNow(getSplitFlapEspNow());
         display.setMqtt(&splitflapMqtt);
         Serial.println("[boot] mqtt setup complete");
         Serial.flush();

--- a/src/SplitFlapDisplay.ino
+++ b/src/SplitFlapDisplay.ino
@@ -40,7 +40,8 @@ JsonSettings settings = JsonSettings("config", {
     {"sclPin", JsonSetting(9)},
     {"stepsPerRot", JsonSetting(2048)},
     {"maxVel", JsonSetting(15.0f)},
-    {"charset", JsonSetting(37)},
+    {"charset", JsonSetting(48)},
+    {"charOffsets", JsonSetting(std::vector<std::vector<int>>(8, std::vector<int>(48, 0)))},
     // Scroll Settings (only applies to messages longer than numModules)
     {"scrollDelayMs", JsonSetting(1500)},
     {"scrollRepeatCount", JsonSetting(2)},
@@ -56,7 +57,7 @@ JsonSettings settings = JsonSettings("config", {
 WiFiClient wifiClient;
 SplitFlapDisplay display(settings);
 SplitFlapEspNow *splitflapEspNow = nullptr;
-SplitFlapWebServer webServer(settings);
+SplitFlapWebServer webServer(settings, display);
 SplitFlapMqtt splitflapMqtt(settings, wifiClient);
 
 bool isMultiDisplayMasterEnabled() {
@@ -301,6 +302,9 @@ void reconnectIfNeeded() {
         }
 
         splitflapMqtt.setup();
+        if (splitflapEspNow) {
+            splitflapEspNow->reinit();
+        }
     }
 }
 

--- a/src/SplitFlapDisplay.ino
+++ b/src/SplitFlapDisplay.ino
@@ -45,6 +45,9 @@ JsonSettings settings = JsonSettings("config", {
     // Scroll Settings (only applies to messages longer than numModules)
     {"scrollDelayMs", JsonSetting(1500)},
     {"scrollRepeatCount", JsonSetting(2)},
+    // Boot / Power Settings
+    {"bootDelayMs", JsonSetting(2000)},          // power-on settle delay; set the slave higher than the master in multi-display setups
+    {"maxConcurrentMotors", JsonSetting(2)},    // cap on simultaneously energized motors during boot homing (1-8)
     // Multi-display master settings
     {"masterGroupCount", JsonSetting(1)},
     {"masterGroupModuleCounts", JsonSetting({8, 8, 8, 8, 8, 8})},
@@ -77,9 +80,26 @@ void setup() {
     Serial.println("[boot] serial ready");
     Serial.flush();
 
-#ifdef STARTUP_DELAY
-    delay(STARTUP_DELAY);
-#endif
+    // Power down all motor coils BEFORE anything else (web server, WiFi,
+    // boot delay). The PCF8575 I/O expanders power up with all outputs
+    // HIGH and the ULN2003 driver boards invert that signal, so at
+    // power-on EVERY coil of EVERY module is energized until the firmware
+    // writes the outputs low. With 11 modules that is several amps on the
+    // shared 5V rail — enough to collapse it below the ESP32's brownout
+    // threshold before the display ever gets to move (observed: 10 modules
+    // survive at ~3.2V, the 11th tips it under 3V and nothing moves).
+    // display.init() writes the init state + stop() to each module, so the
+    // coils are off within milliseconds of setup() starting. The network
+    // bring-up below then runs with the motors unpowered.
+    display.init();
+    Serial.println("[boot] display init complete (motor coils powered down)");
+    Serial.flush();
+
+    // Per-device boot delay: lets the rail settle after power-on (coils
+    // are already off, so this draws almost nothing). In multi-display
+    // setups set the slave's bootDelayMs higher than the master's so the
+    // two boards never energize motors (or transmit WiFi) at the same time.
+    delay(settings.getInt("bootDelayMs"));
 
     Serial.println("Init Web Server");
     Serial.flush();
@@ -97,9 +117,6 @@ void setup() {
         Serial.println("[boot] services started in access point mode");
         Serial.flush();
 
-        display.init();
-        Serial.println("[boot] display init complete");
-        Serial.flush();
         if (getSplitFlapEspNow()->init()) {
             Serial.println("[boot] esp-now initialized successfully");
         } else {
@@ -126,9 +143,6 @@ void setup() {
         Serial.println("[boot] network services started");
         Serial.flush();
 
-        display.init();
-        Serial.println("[boot] display init complete");
-        Serial.flush();
         if (getSplitFlapEspNow()->init()) {
             Serial.println("[boot] esp-now initialized successfully");
         } else {

--- a/src/SplitFlapEspNow.cpp
+++ b/src/SplitFlapEspNow.cpp
@@ -208,18 +208,24 @@ void SplitFlapEspNow::distributeFrame(const String &frame) {
 
     int localModuleCount = getGroupModuleCount(0);
     String localText = sliceMessage(frame, offset, localModuleCount);
+
+    // Send peer chunks first so all remote groups get their text before the
+    // local group begins displaying.
+    for (int groupIndex = 1; groupIndex < groupCount; groupIndex++) {
+        int moduleCount = getGroupModuleCount(groupIndex);
+        String segment = sliceMessage(frame, offset + localModuleCount, moduleCount);
+        Serial.printf("[esp-now] send to group %d text='%s' modules=%d offset=%d\n",
+            groupIndex + 1, segment.c_str(), moduleCount, offset + localModuleCount);
+        sendToPeer(groupIndex, segment, moduleCount);
+        offset += moduleCount;
+    }
+
+    Serial.printf("[esp-now] local group 1 display text='%s' modules=%d\n",
+        localText.c_str(), localModuleCount);
     display.writeString(
         localText, MAX_RPM, false, DEFAULT_SCROLL_DELAY_MS,
         DEFAULT_SCROLL_REPEAT_COUNT, false
     );
-    offset += localModuleCount;
-
-    for (int groupIndex = 1; groupIndex < groupCount; groupIndex++) {
-        int moduleCount = getGroupModuleCount(groupIndex);
-        String segment = sliceMessage(frame, offset, moduleCount);
-        sendToPeer(groupIndex, segment, moduleCount);
-        offset += moduleCount;
-    }
 }
 
 void SplitFlapEspNow::splitIntoChunks(
@@ -346,6 +352,10 @@ bool SplitFlapEspNow::sendToPeer(int groupIndex, const String &text, int moduleC
         peer.encrypt = false;
         peer.ifidx = (WiFi.getMode() == WIFI_AP) ? WIFI_IF_AP : WIFI_IF_STA;
 
+        Serial.printf("[esp-now] adding peer group %d mac %02X:%02X:%02X:%02X:%02X:%02X ifidx=%d\n",
+            groupIndex + 1,
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], peer.ifidx);
+
         esp_err_t addResult = esp_now_add_peer(&peer);
         if (addResult != ESP_OK) {
             Serial.println("[esp-now] failed to add peer for group " + String(groupIndex + 1));
@@ -365,6 +375,9 @@ bool SplitFlapEspNow::sendToPeer(int groupIndex, const String &text, int moduleC
     }
     packet.text[packet.moduleCount] = '\0';
 
+    Serial.printf("[esp-now] send group %d len=%d text='%s'\n",
+        groupIndex + 1, sizeof(packet), packet.text);
+
     esp_err_t result = esp_now_send(mac, (const uint8_t *) &packet, sizeof(packet));
     if (result != ESP_OK) {
         Serial.println("[esp-now] send failed for group " + String(groupIndex + 1));
@@ -376,11 +389,14 @@ bool SplitFlapEspNow::sendToPeer(int groupIndex, const String &text, int moduleC
 
 void SplitFlapEspNow::queueReceived(const uint8_t *data, int len) {
     if (len != sizeof(SplitFlapEspNowMessage)) {
+        Serial.printf("[esp-now] received invalid len=%d\n", len);
         return;
     }
 
     memcpy(&pendingPacket, data, sizeof(pendingPacket));
     pendingMessage = true;
+    Serial.printf("[esp-now] queued received group=%d modules=%d text='%s'\n",
+        pendingPacket.groupIndex + 1, pendingPacket.moduleCount, pendingPacket.text);
 }
 
 #if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3

--- a/src/SplitFlapEspNow.cpp
+++ b/src/SplitFlapEspNow.cpp
@@ -1,0 +1,400 @@
+#include "SplitFlapEspNow.h"
+
+#include <WiFi.h>
+#include <ctype.h>
+#include <string.h>
+
+SplitFlapEspNow *SplitFlapEspNow::instance = nullptr;
+
+SplitFlapEspNow::SplitFlapEspNow(JsonSettings &settings, SplitFlapDisplay &display)
+    : settings(settings), display(display), pendingMessage(false), lastRemoteText(""), initialized(false) {}
+
+bool SplitFlapEspNow::init() {
+    if (initialized) {
+        return true;
+    }
+
+    if (esp_now_init() != ESP_OK) {
+        Serial.println("[esp-now] init failed");
+        return false;
+    }
+
+    instance = this;
+    esp_now_register_recv_cb(handleReceive);
+    initialized = true;
+    Serial.println("[esp-now] initialized on " + WiFi.macAddress());
+    return true;
+}
+
+void SplitFlapEspNow::loop() {
+    if (! initialized || ! pendingMessage) {
+        return;
+    }
+
+    SplitFlapEspNowMessage packet;
+    noInterrupts();
+    memcpy(&packet, &pendingPacket, sizeof(packet));
+    pendingMessage = false;
+    interrupts();
+
+    if (packet.version != ESP_NOW_TEXT_VERSION) {
+        return;
+    }
+
+    int moduleCount = constrain((int) packet.moduleCount, 1, MAX_MODULES);
+    packet.text[moduleCount] = '\0';
+    String text = String(packet.text);
+
+    if (text == lastRemoteText) {
+        return;
+    }
+
+    settings.putInt("mode", ESP_NOW_REMOTE_MODE);
+    display.writeString(
+        text, MAX_RPM, false, DEFAULT_SCROLL_DELAY_MS,
+        DEFAULT_SCROLL_REPEAT_COUNT, false
+    );
+    lastRemoteText = text;
+}
+
+bool SplitFlapEspNow::isMasterEnabled() {
+    return getGroupCount() > 1;
+}
+
+bool SplitFlapEspNow::ensureInitialized() {
+    if (initialized) {
+        return true;
+    }
+
+    if (! isMasterEnabled()) {
+        return false;
+    }
+
+    return init();
+}
+
+void SplitFlapEspNow::distributeMessage(
+    const String &message, bool centering, unsigned long scrollDelayMs,
+    int scrollRepeatCount
+) {
+    if (! ensureInitialized()) {
+        return;
+    }
+
+    int totalModuleCount = getTotalModuleCount();
+
+    if (message.length() <= totalModuleCount) {
+        distributeFrame(buildFrame(message, totalModuleCount, centering));
+        return;
+    }
+
+    int repeats = constrain(
+        scrollRepeatCount, MIN_SCROLL_REPEAT_COUNT, MAX_SCROLL_REPEAT_COUNT
+    );
+    const int maxChunks = MAX_DISPLAY_GROUPS * MAX_MODULES * 4;
+    String chunks[maxChunks];
+    int chunkCount = 0;
+    splitIntoChunks(message, totalModuleCount, chunks, maxChunks, chunkCount);
+
+    Serial.printf(
+        "[esp-now scroll] input=%d chars, totalModules=%d, chunks=%d, repeats=%d\n",
+        message.length(), totalModuleCount, chunkCount, repeats
+    );
+
+    for (int r = 0; r < repeats; r++) {
+        for (int i = 0; i < chunkCount; i++) {
+            distributeFrame(chunks[i]);
+            if (i < chunkCount - 1 || r < repeats - 1) {
+                delay(scrollDelayMs);
+            }
+        }
+    }
+}
+
+int SplitFlapEspNow::getGroupCount() {
+    return constrain(settings.getInt("masterGroupCount"), 1, MAX_DISPLAY_GROUPS);
+}
+
+int SplitFlapEspNow::getGroupModuleCount(int groupIndex) {
+    if (groupIndex == 0) {
+        return constrain(display.getNumModules(), 1, MAX_MODULES);
+    }
+
+    std::vector<int> moduleCounts = settings.getIntVector("masterGroupModuleCounts");
+    if (groupIndex >= 0 && groupIndex < (int) moduleCounts.size()) {
+        return constrain(moduleCounts[groupIndex], 1, MAX_MODULES);
+    }
+
+    return MAX_MODULES;
+}
+
+int SplitFlapEspNow::getTotalModuleCount() {
+    int total = 0;
+    int groupCount = getGroupCount();
+
+    for (int i = 0; i < groupCount; i++) {
+        total += getGroupModuleCount(i);
+    }
+
+    return constrain(total, 1, MAX_DISPLAY_GROUPS * MAX_MODULES);
+}
+
+String SplitFlapEspNow::getGroupMac(int groupIndex) {
+    return getCsvToken(settings.getString("masterGroupMacs"), groupIndex);
+}
+
+String SplitFlapEspNow::getCsvToken(const String &csv, int index) {
+    int tokenStart = 0;
+    int tokenIndex = 0;
+
+    for (int i = 0; i <= (int) csv.length(); i++) {
+        if (i == (int) csv.length() || csv[i] == ',') {
+            if (tokenIndex == index) {
+                String token = csv.substring(tokenStart, i);
+                token.trim();
+                return token;
+            }
+            tokenStart = i + 1;
+            tokenIndex++;
+        }
+    }
+
+    return "";
+}
+
+String SplitFlapEspNow::sliceMessage(const String &message, int start, int width) {
+    String segment = "";
+
+    if (start < (int) message.length()) {
+        segment = message.substring(start, min(start + width, (int) message.length()));
+    }
+
+    while ((int) segment.length() < width) {
+        segment += ' ';
+    }
+
+    return segment;
+}
+
+String SplitFlapEspNow::buildFrame(const String &message, int width, bool centering) {
+    String frame = message.substring(0, min((int) message.length(), width));
+
+    if (centering) {
+        int totalPadding = width - frame.length();
+        int paddingLeft = totalPadding / 2;
+        int paddingRight = totalPadding - paddingLeft;
+
+        String padded = "";
+        for (int i = 0; i < paddingLeft; i++) {
+            padded += ' ';
+        }
+        padded += frame;
+        for (int i = 0; i < paddingRight; i++) {
+            padded += ' ';
+        }
+        return padded;
+    }
+
+    while ((int) frame.length() < width) {
+        frame += ' ';
+    }
+
+    return frame;
+}
+
+void SplitFlapEspNow::distributeFrame(const String &frame) {
+    int groupCount = getGroupCount();
+    int offset = 0;
+
+    int localModuleCount = getGroupModuleCount(0);
+    String localText = sliceMessage(frame, offset, localModuleCount);
+    display.writeString(
+        localText, MAX_RPM, false, DEFAULT_SCROLL_DELAY_MS,
+        DEFAULT_SCROLL_REPEAT_COUNT, false
+    );
+    offset += localModuleCount;
+
+    for (int groupIndex = 1; groupIndex < groupCount; groupIndex++) {
+        int moduleCount = getGroupModuleCount(groupIndex);
+        String segment = sliceMessage(frame, offset, moduleCount);
+        sendToPeer(groupIndex, segment, moduleCount);
+        offset += moduleCount;
+    }
+}
+
+void SplitFlapEspNow::splitIntoChunks(
+    const String &input, int width, String chunks[], int maxChunks,
+    int &outCount
+) {
+    outCount = 0;
+
+    String s = "";
+    bool lastWasSpace = true;
+    for (unsigned int i = 0; i < input.length(); i++) {
+        char c = input[i];
+        bool isSpace = (c == ' ' || c == '\t' || c == '\n' || c == '\r');
+        if (isSpace) {
+            if (! lastWasSpace) {
+                s += ' ';
+                lastWasSpace = true;
+            }
+        } else {
+            s += c;
+            lastWasSpace = false;
+        }
+    }
+    while (s.length() > 0 && s[s.length() - 1] == ' ') {
+        s.remove(s.length() - 1);
+    }
+
+    if (s.length() == 0) {
+        chunks[0] = buildFrame("", width, false);
+        outCount = 1;
+        return;
+    }
+
+    String current = "";
+    int idx = 0;
+    while (idx < (int) s.length() && outCount < maxChunks) {
+        int wordStart = idx;
+        while (wordStart < (int) s.length() && s[wordStart] == ' ') {
+            wordStart++;
+        }
+        if (wordStart >= (int) s.length()) {
+            break;
+        }
+
+        int wordEnd = wordStart;
+        while (wordEnd < (int) s.length() && s[wordEnd] != ' ') {
+            wordEnd++;
+        }
+
+        int wordLen = wordEnd - wordStart;
+        int neededSep = (current.length() > 0) ? 1 : 0;
+        int wouldNeed = (int) current.length() + neededSep + wordLen;
+
+        if (wouldNeed <= width) {
+            if (neededSep) {
+                current += ' ';
+            }
+            current += s.substring(wordStart, wordEnd);
+            idx = wordEnd;
+        } else if (current.length() > 0) {
+            chunks[outCount++] = buildFrame(current, width, false);
+            current = "";
+            idx = wordStart;
+        } else {
+            int remaining = wordLen;
+            int pos = wordStart;
+            while (remaining > width && outCount < maxChunks) {
+                chunks[outCount++] = s.substring(pos, pos + width);
+                pos += width;
+                remaining -= width;
+            }
+            current = s.substring(pos, pos + remaining);
+            idx = wordEnd;
+        }
+    }
+
+    if (current.length() > 0 && outCount < maxChunks) {
+        chunks[outCount++] = buildFrame(current, width, false);
+    }
+}
+
+bool SplitFlapEspNow::parseMacAddress(const String &macString, uint8_t mac[6]) {
+    char hexDigits[13];
+    int digitCount = 0;
+
+    for (int i = 0; i < (int) macString.length(); i++) {
+        char c = macString[i];
+        if (isxdigit((unsigned char) c)) {
+            if (digitCount >= 12) {
+                return false;
+            }
+            hexDigits[digitCount++] = c;
+        } else if (c != ':' && c != '-' && c != ' ') {
+            return false;
+        }
+    }
+
+    if (digitCount != 12) {
+        return false;
+    }
+    hexDigits[12] = '\0';
+
+    for (int i = 0; i < 6; i++) {
+        char byteText[3] = {hexDigits[i * 2], hexDigits[i * 2 + 1], '\0'};
+        mac[i] = (uint8_t) strtol(byteText, nullptr, 16);
+    }
+
+    return true;
+}
+
+bool SplitFlapEspNow::sendToPeer(int groupIndex, const String &text, int moduleCount) {
+    uint8_t mac[6];
+    String macString = getGroupMac(groupIndex);
+
+    if (! parseMacAddress(macString, mac)) {
+        Serial.println("[esp-now] invalid MAC for group " + String(groupIndex + 1) + ": " + macString);
+        return false;
+    }
+
+    if (! esp_now_is_peer_exist(mac)) {
+        esp_now_peer_info_t peer = {};
+        memcpy(peer.peer_addr, mac, 6);
+        peer.channel = 0;
+        peer.encrypt = false;
+        peer.ifidx = (WiFi.getMode() == WIFI_AP) ? WIFI_IF_AP : WIFI_IF_STA;
+
+        esp_err_t addResult = esp_now_add_peer(&peer);
+        if (addResult != ESP_OK) {
+            Serial.println("[esp-now] failed to add peer for group " + String(groupIndex + 1));
+            return false;
+        }
+    }
+
+    SplitFlapEspNowMessage packet = {};
+    packet.version = ESP_NOW_TEXT_VERSION;
+    packet.groupIndex = groupIndex;
+    packet.moduleCount = constrain(moduleCount, 1, MAX_MODULES);
+    memset(packet.text, ' ', sizeof(packet.text));
+
+    int copyLength = min((int) packet.moduleCount, (int) text.length());
+    for (int i = 0; i < copyLength; i++) {
+        packet.text[i] = text[i];
+    }
+    packet.text[packet.moduleCount] = '\0';
+
+    esp_err_t result = esp_now_send(mac, (const uint8_t *) &packet, sizeof(packet));
+    if (result != ESP_OK) {
+        Serial.println("[esp-now] send failed for group " + String(groupIndex + 1));
+        return false;
+    }
+
+    return true;
+}
+
+void SplitFlapEspNow::queueReceived(const uint8_t *data, int len) {
+    if (len != sizeof(SplitFlapEspNowMessage)) {
+        return;
+    }
+
+    memcpy(&pendingPacket, data, sizeof(pendingPacket));
+    pendingMessage = true;
+}
+
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+void SplitFlapEspNow::handleReceive(const esp_now_recv_info_t *info, const uint8_t *data, int len) {
+    (void) info;
+    if (instance) {
+        instance->queueReceived(data, len);
+    }
+}
+#else
+void SplitFlapEspNow::handleReceive(const uint8_t *mac, const uint8_t *data, int len) {
+    (void) mac;
+    if (instance) {
+        instance->queueReceived(data, len);
+    }
+}
+#endif

--- a/src/SplitFlapEspNow.cpp
+++ b/src/SplitFlapEspNow.cpp
@@ -26,6 +26,14 @@ bool SplitFlapEspNow::init() {
     return true;
 }
 
+void SplitFlapEspNow::reinit() {
+    if (initialized) {
+        esp_now_deinit();
+        initialized = false;
+    }
+    init();
+}
+
 void SplitFlapEspNow::loop() {
     if (! initialized || ! pendingMessage) {
         return;

--- a/src/SplitFlapEspNow.h
+++ b/src/SplitFlapEspNow.h
@@ -24,6 +24,7 @@ class SplitFlapEspNow {
     SplitFlapEspNow(JsonSettings &settings, SplitFlapDisplay &display);
 
     bool init();
+    void reinit();
     void loop();
     bool isMasterEnabled();
     void distributeMessage(

--- a/src/SplitFlapEspNow.h
+++ b/src/SplitFlapEspNow.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "JsonSettings.h"
+#include "SplitFlapDisplay.h"
+
+#include <Arduino.h>
+#include <esp_arduino_version.h>
+#include <esp_now.h>
+
+#define MAX_DISPLAY_GROUPS 6
+#define ESP_NOW_REMOTE_MODE 7
+#define ESP_NOW_TEXT_VERSION 1
+
+struct SplitFlapEspNowMessage
+{
+    uint8_t version;
+    uint8_t groupIndex;
+    uint8_t moduleCount;
+    char text[9];
+};
+
+class SplitFlapEspNow {
+  public:
+    SplitFlapEspNow(JsonSettings &settings, SplitFlapDisplay &display);
+
+    bool init();
+    void loop();
+    bool isMasterEnabled();
+    void distributeMessage(
+        const String &message, bool centering = true,
+        unsigned long scrollDelayMs = DEFAULT_SCROLL_DELAY_MS,
+        int scrollRepeatCount = DEFAULT_SCROLL_REPEAT_COUNT
+    );
+
+  private:
+    JsonSettings &settings;
+    SplitFlapDisplay &display;
+
+    volatile bool pendingMessage;
+    SplitFlapEspNowMessage pendingPacket;
+    String lastRemoteText;
+    bool initialized;
+
+    bool ensureInitialized();
+    int getGroupCount();
+    int getGroupModuleCount(int groupIndex);
+    int getTotalModuleCount();
+    String getGroupMac(int groupIndex);
+    String getCsvToken(const String &csv, int index);
+    String sliceMessage(const String &message, int start, int width);
+    String buildFrame(const String &message, int width, bool centering);
+    void distributeFrame(const String &frame);
+    void splitIntoChunks(
+        const String &input, int width, String chunks[], int maxChunks,
+        int &outCount
+    );
+    bool parseMacAddress(const String &macString, uint8_t mac[6]);
+    bool sendToPeer(int groupIndex, const String &text, int moduleCount);
+    void queueReceived(const uint8_t *data, int len);
+
+    static SplitFlapEspNow *instance;
+
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+    static void handleReceive(const esp_now_recv_info_t *info, const uint8_t *data, int len);
+#else
+    static void handleReceive(const uint8_t *mac, const uint8_t *data, int len);
+#endif
+};

--- a/src/SplitFlapModule.cpp
+++ b/src/SplitFlapModule.cpp
@@ -22,13 +22,17 @@ SplitFlapModule::SplitFlapModule()
 
 // Constructor implementation
 SplitFlapModule::SplitFlapModule(
-    uint8_t I2Caddress, int stepsPerFullRotation, int stepOffset, int magnetPos, int charsetSize
+    uint8_t I2Caddress, int stepsPerFullRotation, int stepOffset, int magnetPos, int charsetSize, const int offsets[]
 )
     : address(I2Caddress), position(0), stepNumber(0), stepsPerRot(stepsPerFullRotation), charSetSize(charsetSize) {
     magnetPosition = magnetPos + stepOffset;
 
     chars = (charsetSize == 48) ? ExtendedChars : StandardChars;
     numChars = (charsetSize == 48) ? 48 : 37;
+
+    for (int i = 0; i < 48; i++) {
+        charOffsets[i] = (offsets != nullptr) ? offsets[i] : 0;
+    }
 }
 
 void SplitFlapModule::writeIO(uint16_t data) {
@@ -57,7 +61,7 @@ void SplitFlapModule::init() {
     float stepSize = (float) stepsPerRot / (float) numChars;
     float currentPosition = 0;
     for (int i = 0; i < numChars; i++) {
-        charPositions[i] = (int) currentPosition;
+        charPositions[i] = (int) currentPosition + charOffsets[i];
         currentPosition += stepSize;
     }
 

--- a/src/SplitFlapModule.cpp
+++ b/src/SplitFlapModule.cpp
@@ -85,6 +85,21 @@ void SplitFlapModule::init() {
     stop();
 }
 
+void SplitFlapModule::updateOffsets(const int newCharOffsets[], int newMagnetOffset) {
+    magnetPosition = newMagnetOffset;
+
+    for (int i = 0; i < 48; i++) {
+        charOffsets[i] = newCharOffsets[i];
+    }
+
+    float stepSize = (float) stepsPerRot / (float) numChars;
+    float currentPosition = 0;
+    for (int i = 0; i < numChars; i++) {
+        charPositions[i] = (int) currentPosition + charOffsets[i];
+        currentPosition += stepSize;
+    }
+}
+
 int SplitFlapModule::getCharPosition(char inputChar) {
     inputChar = toupper(inputChar);
     for (int i = 0; i < charSetSize; i++) {

--- a/src/SplitFlapModule.cpp
+++ b/src/SplitFlapModule.cpp
@@ -70,19 +70,11 @@ void SplitFlapModule::init() {
 
     stop();                                  // Write all motor coil inputs LOW
 
-    int initDelay = 100;
-
-    delay(initDelay);
-    step();
-    delay(initDelay);
-    step();
-    delay(initDelay);
-    step();
-    delay(initDelay);
-    step();
-    delay(initDelay);
-
-    stop();
+    // NOTE: this used to "prime" the motor with 4 steps (4x100ms delays).
+    // It serves no functional purpose — homing finds the magnet via the
+    // hall-effect sensor — and it drew coil current for up to 400ms per
+    // module at power-on, when the rail is at its weakest. Removed so the
+    // coils are powered down as early as possible after boot.
 }
 
 void SplitFlapModule::updateOffsets(const int newCharOffsets[], int newMagnetOffset) {

--- a/src/SplitFlapModule.h
+++ b/src/SplitFlapModule.h
@@ -8,7 +8,7 @@ class SplitFlapModule {
     // Constructor declarationS
     SplitFlapModule(); // default constructor required to allocate memory for
     // SplitFlapDisplay class
-    SplitFlapModule(uint8_t I2Caddress, int stepsPerFullRotation, int stepOffset, int magnetPos, int charSetSize);
+    SplitFlapModule(uint8_t I2Caddress, int stepsPerFullRotation, int stepOffset, int magnetPos, int charSetSize, const int charOffsets[] = nullptr);
 
     void init();
 
@@ -44,6 +44,7 @@ class SplitFlapModule {
 
     const char *chars;              // pointer to active character set
     int charPositions[48];          // support up to 48 characters
+    int charOffsets[48];            // per-character step offsets
     int numChars;                   // current number of characters
     int charSetSize;
 

--- a/src/SplitFlapModule.h
+++ b/src/SplitFlapModule.h
@@ -11,6 +11,7 @@ class SplitFlapModule {
     SplitFlapModule(uint8_t I2Caddress, int stepsPerFullRotation, int stepOffset, int magnetPos, int charSetSize, const int charOffsets[] = nullptr);
 
     void init();
+    void updateOffsets(const int newCharOffsets[], int newMagnetOffset);
 
     void step(bool updatePosition = true);                   // step motor
     void stop();                                             // write all motor input pins to low

--- a/src/SplitFlapMotorScheduler.h
+++ b/src/SplitFlapMotorScheduler.h
@@ -1,0 +1,73 @@
+#pragma once
+
+// Pure motor-concurrency scheduler used by SplitFlapDisplay::moveTo().
+//
+// Why it exists: at boot homing every module needs to rotate, and if all
+// motors run at once the combined coil current (28BYJ-48: ~200-330 mA each)
+// can collapse the shared 5 V rail on larger displays (11 modules ≈ 2.2-3.3 A
+// before even considering the PCF8575 POR state). This scheduler caps how
+// many motors may be energized simultaneously so homing runs in small
+// batches instead of one all-motors spike.
+//
+// Deliberately free of Arduino dependencies so the exact logic is
+// unit-testable on the host (see test/motor_scheduler_test.cpp). The
+// firmware calls start()/finish() around the real stepping loop.
+//
+// Semantics:
+//   - start(i)  grants motor i a slot if one is free (or the cap is
+//               unlimited, cap < 0). Returns true when the motor may run.
+//   - finish(i) releases motor i's slot once it reaches its target.
+//   - start(i) on an already-running motor is a no-op returning true
+//     (it keeps its slot; the active count is not double-counted).
+//   - Out-of-range indices are rejected (return false / ignored).
+class SplitFlapMotorScheduler {
+  public:
+    static const int kMaxModules = 8; // must match MAX_MODULES in SplitFlapDisplay.h
+
+    SplitFlapMotorScheduler(int numModules, int maxConcurrent)
+        : numModules_(numModules),
+          maxConcurrent_(maxConcurrent < 0 ? -1 : (maxConcurrent < 1 ? 1 : maxConcurrent)),
+          activeCount_(0) {
+        for (int i = 0; i < kMaxModules; i++) {
+            running_[i] = false;
+        }
+    }
+
+    bool start(int i) {
+        if (i < 0 || i >= numModules_ || i >= kMaxModules) {
+            return false;
+        }
+        if (running_[i]) {
+            return true; // already has a slot
+        }
+        if (maxConcurrent_ >= 0 && activeCount_ >= maxConcurrent_) {
+            return false; // cap reached — caller retries on a later tick
+        }
+        running_[i] = true;
+        activeCount_++;
+        return true;
+    }
+
+    void finish(int i) {
+        if (i < 0 || i >= kMaxModules || i >= numModules_ || !running_[i]) {
+            return;
+        }
+        running_[i] = false;
+        if (activeCount_ > 0) {
+            activeCount_--;
+        }
+    }
+
+    bool isRunning(int i) const {
+        return i >= 0 && i < numModules_ && i < kMaxModules && running_[i];
+    }
+
+    int activeCount() const { return activeCount_; }
+    int numModules() const { return numModules_; }
+
+  private:
+    int numModules_;
+    int maxConcurrent_;
+    int activeCount_;
+    bool running_[kMaxModules];
+};

--- a/src/SplitFlapMqtt.cpp
+++ b/src/SplitFlapMqtt.cpp
@@ -94,7 +94,7 @@ void SplitFlapMqtt::connectToMqtt() {
 
             mqttClient.subscribe(topic_command.c_str());
             mqttClient.publish(topic_avail.c_str(), "online", true);
-            mqttClient.publish(topic_state.c_str(), "", true);
+            mqttClient.publish(topic_state.c_str(), lastPublishedState.c_str(), true);
 
             mqttClient.publish(topic_config_text.c_str(), payload_text.c_str(), true);
             mqttClient.publish(topic_config_sensor.c_str(), payload_sensor.c_str(), true);
@@ -114,6 +114,7 @@ void SplitFlapMqtt::setEspNow(SplitFlapEspNow *e) {
 
 void SplitFlapMqtt::publishState(const String &message) {
     Serial.println("[MQTT] Publishing state: " + message);
+    lastPublishedState = message;        // remember for reconnects
     mqttClient.publish(topic_state.c_str(), message.c_str(), true);
 }
 

--- a/src/SplitFlapMqtt.cpp
+++ b/src/SplitFlapMqtt.cpp
@@ -36,6 +36,13 @@ void SplitFlapMqtt::setup() {
                     settings.getInt("scrollDelayMs"),
                     settings.getInt("scrollRepeatCount")
                 );
+                // Single-group mode publishes the full message via
+                // display->writeString() (publishState defaults to true). In
+                // multi-group mode, writeString is not called, so publish the
+                // state here with the original message (not a per-group slice).
+                if (mqttClient.connected()) {
+                    publishState(message);
+                }
             } else {
                 Serial.println("[MQTT] Displaying message locally on Group 1");
                 display->writeString(message, maxVel, false);

--- a/src/SplitFlapMqtt.cpp
+++ b/src/SplitFlapMqtt.cpp
@@ -27,7 +27,19 @@ void SplitFlapMqtt::setup() {
         Serial.printf("[MQTT] Message received: %s\n", message.c_str());
         if (display) {
             float maxVel = settings.getFloat("maxVel");
-            display->writeString(message, maxVel, false);
+            if (settings.getInt("masterGroupCount") > 1 && espNow) {
+                int groupCount = settings.getInt("masterGroupCount");
+                Serial.printf("[MQTT] masterGroupCount=%d, routing message through ESP-NOW distribution\n", groupCount);
+                espNow->distributeMessage(
+                    message,
+                    false,
+                    settings.getInt("scrollDelayMs"),
+                    settings.getInt("scrollRepeatCount")
+                );
+            } else {
+                Serial.println("[MQTT] Displaying message locally on Group 1");
+                display->writeString(message, maxVel, false);
+            }
         }
     });
 
@@ -94,6 +106,10 @@ void SplitFlapMqtt::connectToMqtt() {
 
 void SplitFlapMqtt::setDisplay(SplitFlapDisplay *d) {
     display = d;
+}
+
+void SplitFlapMqtt::setEspNow(SplitFlapEspNow *e) {
+    espNow = e;
 }
 
 void SplitFlapMqtt::publishState(const String &message) {

--- a/src/SplitFlapMqtt.cpp
+++ b/src/SplitFlapMqtt.cpp
@@ -118,6 +118,13 @@ void SplitFlapMqtt::publishState(const String &message) {
 }
 
 void SplitFlapMqtt::loop() {
+    if (! mqttClient.connected()) {
+        unsigned long now = millis();
+        if (now - lastAttempt > 5000) {
+            lastAttempt = now;
+            connectToMqtt();
+        }
+    }
     mqttClient.loop();
 }
 

--- a/src/SplitFlapMqtt.h
+++ b/src/SplitFlapMqtt.h
@@ -41,4 +41,5 @@ class SplitFlapMqtt {
 
     unsigned long lastAttempt = 0;
     int retryCount = 0;
+    String lastPublishedState;         // mirror of the most recent state publish
 };

--- a/src/SplitFlapMqtt.h
+++ b/src/SplitFlapMqtt.h
@@ -2,6 +2,7 @@
 
 #include "JsonSettings.h"
 #include "SplitFlapDisplay.h"
+#include "SplitFlapEspNow.h"
 
 #include <PubSubClient.h>
 #include <WiFiClient.h>
@@ -14,6 +15,7 @@ class SplitFlapMqtt {
     void loop();                                               // needed for PubSubClient3
     void publishState(const String &message);
     void setDisplay(SplitFlapDisplay *display);
+    void setEspNow(SplitFlapEspNow *espNow);
     bool isConnected();
 
   private:
@@ -22,6 +24,7 @@ class SplitFlapMqtt {
 
     JsonSettings &settings;
     SplitFlapDisplay *display;
+    SplitFlapEspNow *espNow = nullptr;
 
     void connectToMqtt();
 

--- a/src/SplitFlapWebServer.cpp
+++ b/src/SplitFlapWebServer.cpp
@@ -14,8 +14,8 @@
 #define WIFI_PASS ""
 #endif
 
-SplitFlapWebServer::SplitFlapWebServer(JsonSettings &settings)
-    : settings(settings), server(80), multiWordDelay(1000), rebootRequired(false), attemptReconnect(false),
+SplitFlapWebServer::SplitFlapWebServer(JsonSettings &settings, SplitFlapDisplay &display)
+    : settings(settings), display(display), server(80), multiWordDelay(1000), rebootRequired(false), attemptReconnect(false),
       multiWordCurrentIndex(0), numMultiWords(0), wifiCheckInterval(1000), connectionMode(0), checkDateInterval(250),
       centering(1) {
     lastSwitchMultiTime = millis();
@@ -44,8 +44,9 @@ void SplitFlapWebServer::setTimezone() {
     }
 
     size_t size = file.size();
-    std::unique_ptr<char[]> buffer(new char[size]);
+    std::unique_ptr<char[]> buffer(new char[size + 1]);
     file.readBytes(buffer.get(), size);
+    buffer[size] = '\0';
     file.close();
 
     JsonDocument timezones;
@@ -298,10 +299,9 @@ void SplitFlapWebServer::endMDNS() {
 
 void SplitFlapWebServer::startMDNS() {
     if (! MDNS.begin(settings.getString("mdns").c_str())) {
-        Serial.println("Error setting up MDNS responder!");
-        while (1) {
-            delay(1000);
-        }
+        Serial.println("Error setting up MDNS responder! Restarting...");
+        delay(1000);
+        ESP.restart();
     }
 
     Serial.println("mDNS: http://" + settings.getString("mdns") + ".local");
@@ -397,12 +397,28 @@ void SplitFlapWebServer::startWebServer() {
             return request->send(400, "application/json", response.as<String>());
         }
 
+        bool offsetsChanged = false;
+        if (json["moduleOffsets"].is<String>() && json["moduleOffsets"].as<String>() != settings.getString("moduleOffsets")) {
+            offsetsChanged = true;
+        }
+        if (json["charOffsets"].is<String>() && json["charOffsets"].as<String>() != settings.getString("charOffsets")) {
+            offsetsChanged = true;
+        }
+        if (json["displayOffset"].is<int>() && json["displayOffset"].as<int>() != settings.getInt("displayOffset")) {
+            offsetsChanged = true;
+        }
+
         if (! settings.fromJson(json)) {
             response["message"] = "Failed to save settings";
             response["type"] = "error";
             response["errors"]["key"] = settings.getLastValidationKey();
             response["errors"]["message"] = settings.getLastValidationError();
             return request->send(400, "application/json", response.as<String>());
+        }
+
+        if (offsetsChanged) {
+            display.reloadOffsets();
+            response["message"] = "Settings saved and offsets applied!";
         }
 
         response["type"] = "success";

--- a/src/SplitFlapWebServer.cpp
+++ b/src/SplitFlapWebServer.cpp
@@ -2,6 +2,7 @@
 
 #include <ArduinoJson.h>
 #include <AsyncJson.h>
+#include <ctype.h>
 
 #define AP_SSID "Split Flap Display"
 
@@ -329,7 +330,11 @@ void SplitFlapWebServer::startWebServer() {
     }
 
     server.on("/settings", HTTP_GET, [this](AsyncWebServerRequest *request) {
-        request->send(200, "application/json", settings.toJson().as<String>());
+        JsonDocument currentSettings = settings.toJson();
+        JsonDocument response;
+        response["settings"] = currentSettings.as<JsonObject>();
+        response["localMac"] = WiFi.macAddress();
+        request->send(200, "application/json", response.as<String>());
     });
 
     server.on("/settings/reset", HTTP_POST, [this](AsyncWebServerRequest *request) {
@@ -353,7 +358,6 @@ void SplitFlapWebServer::startWebServer() {
 
         Serial.println("Received settings update request");
         Serial.println(json.as<String>());
-
         bool rebootRequired = false;
         bool reconnect = false;
         JsonDocument response;
@@ -387,6 +391,10 @@ void SplitFlapWebServer::startWebServer() {
             (json["mqtt_pass"].is<String>() && json["mqtt_pass"].as<String>() != settings.getString("mqtt_pass"))) {
             response["message"] = "Mqtt settings have changed, reconnecting...";
             reconnect = true;
+        }
+
+        if (! validateMasterSettings(json, response)) {
+            return request->send(400, "application/json", response.as<String>());
         }
 
         if (! settings.fromJson(json)) {
@@ -522,4 +530,121 @@ String SplitFlapWebServer::decodeURIComponent(String encodedString) {
     decodedString.replace("%7E", "~");  // tilde
 
     return decodedString;
+}
+
+bool SplitFlapWebServer::validateMasterSettings(JsonVariant &json, JsonDocument &response) {
+    const int maxDisplayGroups = 6;
+    const int maxModulesPerGroup = 8;
+
+    int groupCount = settings.getInt("masterGroupCount");
+    if (! json["masterGroupCount"].isNull()) {
+        if (! json["masterGroupCount"].is<int>()) {
+            response["message"] = "Master group count must be a number";
+            response["type"] = "error";
+            response["errors"]["key"] = "masterGroupCount";
+            response["errors"]["message"] = "Enter a value from 1 to 6";
+            return false;
+        }
+        groupCount = json["masterGroupCount"].as<int>();
+    }
+
+    if (groupCount < 1 || groupCount > maxDisplayGroups) {
+        response["message"] = "Master group count must be between 1 and 6";
+        response["type"] = "error";
+        response["errors"]["key"] = "masterGroupCount";
+        response["errors"]["message"] = "Enter a value from 1 to 6";
+        return false;
+    }
+
+    String moduleCounts = settings.getString("masterGroupModuleCounts");
+    if (! json["masterGroupModuleCounts"].isNull()) {
+        if (! json["masterGroupModuleCounts"].is<String>()) {
+            response["message"] = "Group module counts must be comma-separated numbers";
+            response["type"] = "error";
+            response["errors"]["key"] = "masterGroupModuleCounts";
+            response["errors"]["message"] = "Use one number per group";
+            return false;
+        }
+        moduleCounts = json["masterGroupModuleCounts"].as<String>();
+    }
+
+    for (int i = 0; i < groupCount; i++) {
+        String token = getCsvToken(moduleCounts, i);
+        if (token.length() == 0) {
+            response["message"] = "Each active group needs a module count";
+            response["type"] = "error";
+            response["errors"]["key"] = "masterGroupModuleCounts";
+            response["errors"]["message"] = "Enter 1 to 8 modules for each active group";
+            return false;
+        }
+
+        int value = token.toInt();
+        if (value < 1 || value > maxModulesPerGroup) {
+            response["message"] = "Each group can have 1 to 8 modules";
+            response["type"] = "error";
+            response["errors"]["key"] = "masterGroupModuleCounts";
+            response["errors"]["message"] = "Hardware limit is 8 modules per group";
+            return false;
+        }
+    }
+
+    String macs = settings.getString("masterGroupMacs");
+    if (! json["masterGroupMacs"].isNull()) {
+        if (! json["masterGroupMacs"].is<String>()) {
+            response["message"] = "Group MAC addresses must be text";
+            response["type"] = "error";
+            response["errors"]["key"] = "masterGroupMacs";
+            response["errors"]["message"] = "Use MAC addresses like AA:BB:CC:DD:EE:FF";
+            return false;
+        }
+        macs = json["masterGroupMacs"].as<String>();
+    }
+
+    for (int i = 1; i < groupCount; i++) {
+        String mac = getCsvToken(macs, i);
+        if (! validateMacAddress(mac)) {
+            response["message"] = "Each remote group needs a valid MAC address";
+            response["type"] = "error";
+            response["errors"]["key"] = "masterGroupMacs";
+            response["errors"]["message"] = "Use MAC addresses like AA:BB:CC:DD:EE:FF";
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool SplitFlapWebServer::validateMacAddress(String macString) {
+    macString.trim();
+    int digitCount = 0;
+
+    for (int i = 0; i < (int) macString.length(); i++) {
+        char c = macString[i];
+        if (isxdigit((unsigned char) c)) {
+            digitCount++;
+        } else if (c != ':' && c != '-' && c != ' ') {
+            return false;
+        }
+    }
+
+    return digitCount == 12;
+}
+
+String SplitFlapWebServer::getCsvToken(const String &csv, int index) {
+    int tokenStart = 0;
+    int tokenIndex = 0;
+
+    for (int i = 0; i <= (int) csv.length(); i++) {
+        if (i == (int) csv.length() || csv[i] == ',') {
+            if (tokenIndex == index) {
+                String token = csv.substring(tokenStart, i);
+                token.trim();
+                return token;
+            }
+            tokenStart = i + 1;
+            tokenIndex++;
+        }
+    }
+
+    return "";
 }

--- a/src/SplitFlapWebServer.h
+++ b/src/SplitFlapWebServer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "JsonSettings.h"
+#include "SplitFlapDisplay.h"
 
 #include <Arduino.h>
 #include <ArduinoJson.h>
@@ -13,7 +14,7 @@
 
 class SplitFlapWebServer {
   public:
-    SplitFlapWebServer(JsonSettings &settings);
+    SplitFlapWebServer(JsonSettings &settings, SplitFlapDisplay &display);
     void init();
     void setTimezone();
     void checkRebootRequired();
@@ -66,6 +67,7 @@ class SplitFlapWebServer {
 
   private:
     JsonSettings &settings;
+    SplitFlapDisplay &display;
 
     String decodeURIComponent(String encodedString);
     bool validateMasterSettings(JsonVariant &json, JsonDocument &response);

--- a/src/SplitFlapWebServer.h
+++ b/src/SplitFlapWebServer.h
@@ -68,6 +68,9 @@ class SplitFlapWebServer {
     JsonSettings &settings;
 
     String decodeURIComponent(String encodedString);
+    bool validateMasterSettings(JsonVariant &json, JsonDocument &response);
+    bool validateMacAddress(String macString);
+    String getCsvToken(const String &csv, int index);
     void setInputString(String input) { inputString = input; }
     void setMultiInputString(String input) { multiInputString = input; }
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -36,11 +36,11 @@
                 <option value="2">Date</option>
                 <option value="3">Time</option>
                 <!--        <option value="4">Count</option>-->
-                <option value="6">Custom Text</option>
+                <option value="0">Custom Text</option>
                 <option value="5">Random</option>
             </select>
 
-            <template x-if="settings.mode == 6">
+            <template x-if="settings.mode == 0">
                 <div class="w-full">
                     <div class="flex items-center justify-between gap-4 mb-4">
                         <div class="flex items-center gap-4">

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -173,6 +173,10 @@
                 class="p-3 mt-4 text-lg font-semibold text-white hover:text-amber-600 text-center block transition-colors"
                 >Settings</a
             >
+            <div class="w-full text-left text-sm text-gray-400 mt-2">
+                <span class="font-semibold">Device MAC:</span>
+                <span x-text="localMac || 'Unavailable'"></span>
+            </div>
         </div>
         <div
             class="fixed top-4 left-1/2 transform -translate-x-1/2 p-4 text-white rounded-md transition duration-300"

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -68,6 +68,48 @@ document.addEventListener("alpine:init", () => {
             this.settings.moduleOffsets = arr.join(",");
         },
 
+        get charOffsetMatrix() {
+            if (!this.settings.charOffsets) return [];
+            return this.settings.charOffsets
+                .split(";")
+                .filter((r) => r.length > 0)
+                .map((r) => r.split(",").map((v) => parseInt(v) || 0));
+        },
+        setCharOffset(modIndex, charIndex, value) {
+            const matrix = this.charOffsetMatrix;
+            while (matrix.length <= modIndex) matrix.push([]);
+            while (matrix[modIndex].length <= charIndex)
+                matrix[modIndex].push(0);
+            matrix[modIndex][charIndex] = parseInt(value) || 0;
+            this.settings.charOffsets = matrix
+                .map((r) => r.join(","))
+                .join(";");
+        },
+        resetCharOffsets(modIndex) {
+            const matrix = this.charOffsetMatrix;
+            const numChars = this.settings.charset || 48;
+            while (matrix.length <= modIndex) matrix.push([]);
+            matrix[modIndex] = Array(numChars).fill(0);
+            this.settings.charOffsets = matrix
+                .map((r) => r.join(","))
+                .join(";");
+        },
+        copyCharOffsets(fromIndex, toIndex) {
+            const matrix = this.charOffsetMatrix;
+            if (fromIndex >= matrix.length) return;
+            while (matrix.length <= toIndex) matrix.push([]);
+            matrix[toIndex] = [...matrix[fromIndex]];
+            this.settings.charOffsets = matrix
+                .map((r) => r.join(","))
+                .join(";");
+        },
+
+        get charsetChars() {
+            const standard = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            const extended = standard + "'?:!.-/$@#%";
+            return (this.settings.charset || 48) === 48 ? extended : standard;
+        },
+
         get groupModuleArray() {
             const arr =
                 this.settings.masterGroupModuleCounts

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -21,7 +21,11 @@ document.addEventListener("alpine:init", () => {
             mode: 2,
             dateFormat: "ddd dd/MM",
             timeFormat: "HH:mm",
+            masterGroupCount: 1,
+            masterGroupModuleCounts: "8,8,8,8,8,8",
+            masterGroupMacs: ",,,,,",
         },
+        localMac: "",
         errors: {},
         timezones: {},
 
@@ -64,6 +68,57 @@ document.addEventListener("alpine:init", () => {
             this.settings.moduleOffsets = arr.join(",");
         },
 
+        get groupModuleArray() {
+            const arr =
+                this.settings.masterGroupModuleCounts
+                    ?.split(",")
+                    .map((s) => s.trim()) || [];
+            while (arr.length < 6) {
+                arr.push("8");
+            }
+            arr[0] = String(this.settings.moduleCount || arr[0] || 8);
+            return arr.slice(0, 6);
+        },
+        setGroupModuleCount(index, value) {
+            const arr = this.groupModuleArray;
+            arr[index] = value;
+            if (index === 0) {
+                this.settings.moduleCount = value;
+            }
+            this.settings.masterGroupModuleCounts = arr.join(",");
+        },
+
+        get groupMacArray() {
+            const arr =
+                this.settings.masterGroupMacs
+                    ?.split(",")
+                    .map((s) => s.trim()) || [];
+            while (arr.length < 6) {
+                arr.push("");
+            }
+            return arr.slice(0, 6);
+        },
+        setGroupMac(index, value) {
+            const arr = this.groupMacArray;
+            arr[index] = value;
+            this.settings.masterGroupMacs = arr.join(",");
+        },
+
+        normalizeMasterGroups() {
+            const groupCount = Number(this.settings.masterGroupCount || 1);
+            this.settings.masterGroupCount = Math.min(
+                Math.max(groupCount, 1),
+                6,
+            );
+
+            const counts = this.groupModuleArray;
+            counts[0] = String(this.settings.moduleCount || counts[0] || 8);
+            this.settings.masterGroupModuleCounts = counts.join(",");
+
+            const macs = this.groupMacArray;
+            this.settings.masterGroupMacs = macs.join(",");
+        },
+
         init() {
             this.loadSettings();
             if (type === "Settings") {
@@ -75,7 +130,10 @@ document.addEventListener("alpine:init", () => {
             fetch("/settings")
                 .then((res) => res.json())
                 .then((data) => {
-                    Object.assign(this.settings, data);
+                    const settingsData = data.settings || {};
+                    Object.assign(this.settings, settingsData);
+                    this.localMac = data.localMac || "";
+                    this.normalizeMasterGroups();
                 })
                 .catch(() =>
                     this.showDialog("Failed to load settings", "error", true),
@@ -102,7 +160,7 @@ document.addEventListener("alpine:init", () => {
         },
 
         updateDisplay() {
-            if (this.settings.mode === 6) {
+            if (this.settings.mode === 0) {
                 if (this.delay < 1) {
                     return this.showDialog(
                         "Delay must be at least 1 second.",
@@ -131,7 +189,7 @@ document.addEventListener("alpine:init", () => {
                 body: JSON.stringify({ mode: this.settings.mode }),
             });
 
-            if (this.settings.mode === 6) {
+            if (this.settings.mode === 0) {
                 fetch("/text", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
@@ -166,6 +224,7 @@ document.addEventListener("alpine:init", () => {
         save() {
             this.saving = true;
             this.errors = {};
+            this.normalizeMasterGroups();
 
             fetch("/settings", {
                 method: "POST",

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -106,7 +106,7 @@ document.addEventListener("alpine:init", () => {
 
         get charsetChars() {
             const standard = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-            const extended = standard + "'?:!.-/$@#%";
+            const extended = standard + "':?!.-/$@#%";
             return (this.settings.charset || 48) === 48 ? extended : standard;
         },
 

--- a/src/web/index.test.js
+++ b/src/web/index.test.js
@@ -1,0 +1,847 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const createPageData = (type = "Settings") => {
+    return {
+        get header() {
+            return this.settings.name || "Split Flap";
+        },
+
+        loading: {
+            settings: true,
+            timezones: true,
+        },
+        saving: false,
+        dialog: {
+            show: false,
+            message: "",
+            type: null,
+        },
+        settings: {
+            mode: 2,
+            dateFormat: "ddd dd/MM",
+            timeFormat: "HH:mm",
+            masterGroupCount: 1,
+            masterGroupModuleCounts: "8,8,8,8,8,8",
+            masterGroupMacs: ",,,,,",
+        },
+        localMac: "",
+        errors: {},
+        timezones: {},
+
+        singleMode: true,
+        singleWord: "",
+        multiWord: "",
+        multiWords: [],
+        delay: 1,
+        centerText: false,
+
+        get processing() {
+            return (
+                this.saving || this.loading.settings || this.loading.timezones
+            );
+        },
+
+        get addressArray() {
+            return (
+                this.settings.moduleAddresses
+                    ?.split(",")
+                    .map((s) => s.trim()) || []
+            );
+        },
+        setAddress(index, value) {
+            const arr = this.addressArray;
+            arr[index] = value;
+            this.settings.moduleAddresses = arr.join(",");
+        },
+
+        get offsetArray() {
+            return (
+                this.settings.moduleOffsets?.split(",").map((s) => s.trim()) ||
+                []
+            );
+        },
+        setOffset(index, value) {
+            const arr = this.offsetArray;
+            arr[index] = value;
+            this.settings.moduleOffsets = arr.join(",");
+        },
+
+        get charOffsetMatrix() {
+            if (!this.settings.charOffsets) return [];
+            return this.settings.charOffsets
+                .split(";")
+                .filter((r) => r.length > 0)
+                .map((r) => r.split(",").map((v) => parseInt(v) || 0));
+        },
+        setCharOffset(modIndex, charIndex, value) {
+            const matrix = this.charOffsetMatrix;
+            while (matrix.length <= modIndex) matrix.push([]);
+            while (matrix[modIndex].length <= charIndex)
+                matrix[modIndex].push(0);
+            matrix[modIndex][charIndex] = parseInt(value) || 0;
+            this.settings.charOffsets = matrix
+                .map((r) => r.join(","))
+                .join(";");
+        },
+        resetCharOffsets(modIndex) {
+            const matrix = this.charOffsetMatrix;
+            const numChars = this.settings.charset || 48;
+            while (matrix.length <= modIndex) matrix.push([]);
+            matrix[modIndex] = Array(numChars).fill(0);
+            this.settings.charOffsets = matrix
+                .map((r) => r.join(","))
+                .join(";");
+        },
+        copyCharOffsets(fromIndex, toIndex) {
+            const matrix = this.charOffsetMatrix;
+            if (fromIndex >= matrix.length) return;
+            while (matrix.length <= toIndex) matrix.push([]);
+            matrix[toIndex] = [...matrix[fromIndex]];
+            this.settings.charOffsets = matrix
+                .map((r) => r.join(","))
+                .join(";");
+        },
+
+        get charsetChars() {
+            const standard = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            const extended = standard + "'?:!.-/$@#%";
+            return (this.settings.charset || 48) === 48 ? extended : standard;
+        },
+
+        get groupModuleArray() {
+            const arr =
+                this.settings.masterGroupModuleCounts
+                    ?.split(",")
+                    .map((s) => s.trim()) || [];
+            while (arr.length < 6) {
+                arr.push("8");
+            }
+            arr[0] = String(this.settings.moduleCount || arr[0] || 8);
+            return arr.slice(0, 6);
+        },
+        setGroupModuleCount(index, value) {
+            const arr = this.groupModuleArray;
+            arr[index] = value;
+            if (index === 0) {
+                this.settings.moduleCount = value;
+            }
+            this.settings.masterGroupModuleCounts = arr.join(",");
+        },
+
+        get groupMacArray() {
+            const arr =
+                this.settings.masterGroupMacs
+                    ?.split(",")
+                    .map((s) => s.trim()) || [];
+            while (arr.length < 6) {
+                arr.push("");
+            }
+            return arr.slice(0, 6);
+        },
+        setGroupMac(index, value) {
+            const arr = this.groupMacArray;
+            arr[index] = value;
+            this.settings.masterGroupMacs = arr.join(",");
+        },
+
+        normalizeMasterGroups() {
+            const groupCount = Number(this.settings.masterGroupCount || 1);
+            this.settings.masterGroupCount = Math.min(
+                Math.max(groupCount, 1),
+                6,
+            );
+
+            const counts = this.groupModuleArray;
+            counts[0] = String(this.settings.moduleCount || counts[0] || 8);
+            this.settings.masterGroupModuleCounts = counts.join(",");
+
+            const macs = this.groupMacArray;
+            this.settings.masterGroupMacs = macs.join(",");
+        },
+
+        init() {
+            this.loadSettings();
+            if (type === "Settings") {
+                this.loadTimezones();
+            }
+        },
+
+        loadSettings() {
+            fetch("/settings")
+                .then((res) => res.json())
+                .then((data) => {
+                    const settingsData = data.settings || {};
+                    Object.assign(this.settings, settingsData);
+                    this.localMac = data.localMac || "";
+                    this.normalizeMasterGroups();
+                })
+                .catch(() =>
+                    this.showDialog("Failed to load settings", "error", true),
+                )
+                .finally(() => {
+                    this.loading.settings = false;
+                });
+        },
+
+        loadTimezones() {
+            fetch("/timezones.json")
+                .then((res) => res.json())
+                .then((data) => {
+                    this.timezones = data;
+                })
+                .catch(() =>
+                    this.showDialog(
+                        "Failed to load timezones. Refresh the page.",
+                        "error",
+                        true,
+                    ),
+                )
+                .finally(() => (this.loading.timezones = false));
+        },
+
+        updateDisplay() {
+            if (this.settings.mode === 0) {
+                if (this.delay < 1) {
+                    return this.showDialog(
+                        "Delay must be at least 1 second.",
+                        "error",
+                    );
+                }
+
+                if (this.singleMode && this.singleWord.trim() === "") {
+                    return this.showDialog(
+                        "Single word cannot be empty.",
+                        "error",
+                    );
+                }
+
+                if (!this.singleMode && this.multiWords.length === 0) {
+                    return this.showDialog(
+                        "Word list cannot be empty.",
+                        "error",
+                    );
+                }
+            }
+
+            fetch("/settings", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ mode: this.settings.mode }),
+            });
+
+            if (this.settings.mode === 0) {
+                fetch("/text", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        mode: this.singleMode ? "single" : "multiple",
+                        words: this.singleMode
+                            ? [this.singleWord]
+                            : this.multiWords,
+                        delay: this.delay,
+                        center: this.centerText,
+                    }),
+                })
+                    .then((res) => res.json())
+                    .then((res) => this.showDialog(res.message, res.type))
+                    .catch((err) => this.showDialog(err.message, "error"));
+            } else {
+                this.showDialog("Mode updated successfully.", "success");
+            }
+        },
+
+        addWord() {
+            if (this.multiWord.trim() !== "") {
+                this.multiWords.push(this.multiWord.trim());
+            }
+            this.multiWord = "";
+        },
+
+        removeWord(index) {
+            this.multiWords.splice(index, 1);
+        },
+
+        save() {
+            this.saving = true;
+            this.errors = {};
+            this.normalizeMasterGroups();
+
+            fetch("/settings", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(this.settings),
+            })
+                .then((res) => res.json())
+                .then((data) => {
+                    this.errors = data.errors || {};
+                    this.showDialog(data.message, data.type, data.persistent);
+                    if (data.redirect) {
+                        setTimeout(() => {
+                            window.location.href = data.redirect;
+                        }, 10000);
+                    }
+                })
+                .catch(() =>
+                    this.showDialog("Failed to save settings.", "error"),
+                )
+                .finally(() => (this.saving = false));
+        },
+
+        reset() {
+            if (
+                confirm("Are you sure you want to reset settings to defaults?")
+            ) {
+                fetch("/settings/reset", { method: "POST" })
+                    .then((res) => res.json())
+                    .then((data) => {
+                        this.showDialog(
+                            data.message,
+                            data.type,
+                            data.persistent,
+                        );
+                        this.loadSettings();
+                    })
+                    .catch(() => {
+                        this.showDialog("Failed to reset settings.", "error");
+                    });
+            }
+        },
+
+        showDialog(message, type = "success", persistent = false) {
+            this.dialog.message = message;
+            this.dialog.type = type;
+            this.dialog.show = true;
+
+            if (!persistent) {
+                setTimeout(() => (this.dialog.show = false), 3000);
+            }
+        },
+    };
+};
+
+describe("Page Component - Module Offsets", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+    });
+
+    it("should return empty array when moduleOffsets is undefined", () => {
+        expect(page.offsetArray).toEqual([]);
+    });
+
+    it("should parse comma-separated offset string", () => {
+        page.settings.moduleOffsets = "10,20,30";
+        expect(page.offsetArray).toEqual(["10", "20", "30"]);
+    });
+
+    it("should set offset at specific index", () => {
+        page.settings.moduleOffsets = "0,0,0";
+        page.setOffset(1, "15");
+        expect(page.settings.moduleOffsets).toBe("0,15,0");
+    });
+
+    it("should handle setting offset on empty array", () => {
+        page.setOffset(2, "25");
+        expect(page.offsetArray[2]).toBe("25");
+    });
+});
+
+describe("Page Component - Character Offsets", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+        page.settings.charset = 48;
+    });
+
+    it("should return empty array when charOffsets is undefined", () => {
+        expect(page.charOffsetMatrix).toEqual([]);
+    });
+
+    it("should parse semicolon-separated rows with comma values", () => {
+        page.settings.charOffsets = "1,2,3;4,5,6";
+        expect(page.charOffsetMatrix).toEqual([
+            [1, 2, 3],
+            [4, 5, 6],
+        ]);
+    });
+
+    it("should handle empty rows", () => {
+        page.settings.charOffsets = "1,2;;4,5";
+        expect(page.charOffsetMatrix).toEqual([
+            [1, 2],
+            [4, 5],
+        ]);
+    });
+
+    it("should set character offset at specific module and character", () => {
+        page.settings.charOffsets = "0,0,0;0,0,0";
+        page.setCharOffset(1, 2, 10);
+        expect(page.charOffsetMatrix).toEqual([
+            [0, 0, 0],
+            [0, 0, 10],
+        ]);
+    });
+
+    it("should expand matrix when setting offset beyond current size", () => {
+        page.settings.charOffsets = "1,2";
+        page.setCharOffset(1, 3, 5);
+        const matrix = page.charOffsetMatrix;
+        expect(matrix.length).toBe(2);
+        expect(matrix[1][3]).toBe(5);
+    });
+
+    it("should handle non-numeric values as 0", () => {
+        page.setCharOffset(0, 0, "abc");
+        expect(page.charOffsetMatrix[0][0]).toBe(0);
+    });
+
+    it("should reset character offsets for a module", () => {
+        page.settings.charOffsets = "1,2,3;4,5,6;7,8,9";
+        page.settings.charset = 3;
+        page.resetCharOffsets(1);
+        expect(page.charOffsetMatrix).toEqual([
+            [1, 2, 3],
+            [0, 0, 0],
+            [7, 8, 9],
+        ]);
+    });
+
+    it("should reset using charset size (48)", () => {
+        page.settings.charset = 48;
+        page.settings.charOffsets = "1,2,3";
+        page.resetCharOffsets(0);
+        expect(page.charOffsetMatrix[0].length).toBe(48);
+        expect(page.charOffsetMatrix[0].every((v) => v === 0)).toBe(true);
+    });
+
+    it("should copy character offsets from one module to another", () => {
+        page.settings.charOffsets = "1,2,3;4,5,6;7,8,9";
+        page.copyCharOffsets(0, 2);
+        expect(page.charOffsetMatrix[2]).toEqual([1, 2, 3]);
+    });
+
+    it("should not copy from invalid source module", () => {
+        page.settings.charOffsets = "1,2,3";
+        page.copyCharOffsets(5, 0);
+        expect(page.charOffsetMatrix).toEqual([[1, 2, 3]]);
+    });
+
+    it("should expand target module when copying", () => {
+        page.settings.charOffsets = "1,2,3;4,5,6";
+        page.copyCharOffsets(0, 2);
+        expect(page.charOffsetMatrix.length).toBe(3);
+        expect(page.charOffsetMatrix[2]).toEqual([1, 2, 3]);
+    });
+});
+
+describe("Page Component - Charset Characters", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+    });
+
+    it("should return extended charset (48 chars) by default", () => {
+        page.settings.charset = 48;
+        expect(page.charsetChars.length).toBe(48);
+        expect(page.charsetChars).toContain("'");
+        expect(page.charsetChars).toContain("%");
+    });
+
+    it("should return standard charset (37 chars) when set", () => {
+        page.settings.charset = 37;
+        expect(page.charsetChars.length).toBe(37);
+        expect(page.charsetChars).not.toContain("'");
+    });
+
+    it("should start with space character", () => {
+        expect(page.charsetChars[0]).toBe(" ");
+    });
+
+    it("should contain all letters A-Z", () => {
+        for (let i = 65; i <= 90; i++) {
+            expect(page.charsetChars).toContain(String.fromCharCode(i));
+        }
+    });
+
+    it("should contain all digits 0-9", () => {
+        for (let i = 0; i <= 9; i++) {
+            expect(page.charsetChars).toContain(String(i));
+        }
+    });
+});
+
+describe("Page Component - Module Addresses", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+    });
+
+    it("should return empty array when moduleAddresses is undefined", () => {
+        expect(page.addressArray).toEqual([]);
+    });
+
+    it("should parse comma-separated address string", () => {
+        page.settings.moduleAddresses = "32, 33, 34";
+        expect(page.addressArray).toEqual(["32", "33", "34"]);
+    });
+
+    it("should set address at specific index", () => {
+        page.settings.moduleAddresses = "32,33,34";
+        page.setAddress(1, "35");
+        expect(page.settings.moduleAddresses).toBe("32,35,34");
+    });
+});
+
+describe("Page Component - Master Groups", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+    });
+
+    it("should return group module array with defaults", () => {
+        expect(page.groupModuleArray).toEqual(["8", "8", "8", "8", "8", "8"]);
+    });
+
+    it("should normalize master group count to 1-6 range", () => {
+        page.settings.masterGroupCount = 0;
+        page.normalizeMasterGroups();
+        expect(page.settings.masterGroupCount).toBe(1);
+
+        page.settings.masterGroupCount = 10;
+        page.normalizeMasterGroups();
+        expect(page.settings.masterGroupCount).toBe(6);
+    });
+
+    it("should set group module count and update moduleCount for index 0", () => {
+        page.setGroupModuleCount(0, 4);
+        expect(page.settings.moduleCount).toBe(4);
+        expect(page.groupModuleArray[0]).toBe("4");
+    });
+
+    it("should set group module count without changing moduleCount for other indices", () => {
+        page.settings.moduleCount = 8;
+        page.setGroupModuleCount(2, 6);
+        expect(page.settings.moduleCount).toBe(8);
+        expect(page.groupModuleArray[2]).toBe("6");
+    });
+
+    it("should return group MAC array with defaults", () => {
+        expect(page.groupMacArray).toEqual(["", "", "", "", "", ""]);
+    });
+
+    it("should set group MAC at specific index", () => {
+        page.setGroupMac(1, "AA:BB:CC:DD:EE:FF");
+        expect(page.groupMacArray[1]).toBe("AA:BB:CC:DD:EE:FF");
+    });
+});
+
+describe("Page Component - Load Settings", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+        global.fetch = vi.fn();
+    });
+
+    it("should load settings from /settings endpoint", async () => {
+        const mockSettings = {
+            settings: {
+                name: "Test Display",
+                moduleCount: 4,
+                moduleOffsets: "1,2,3,4",
+                charset: 48,
+            },
+            localMac: "AA:BB:CC:DD:EE:FF",
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            json: () => Promise.resolve(mockSettings),
+        });
+
+        page.loadSettings();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(global.fetch).toHaveBeenCalledWith("/settings");
+        expect(page.settings.name).toBe("Test Display");
+        expect(page.settings.moduleCount).toBe(4);
+        expect(page.localMac).toBe("AA:BB:CC:DD:EE:FF");
+        expect(page.loading.settings).toBe(false);
+    });
+
+    it("should handle load settings failure", async () => {
+        global.fetch.mockRejectedValueOnce(new Error("Network error"));
+
+        page.loadSettings();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(page.dialog.show).toBe(true);
+        expect(page.dialog.type).toBe("error");
+        expect(page.loading.settings).toBe(false);
+    });
+});
+
+describe("Page Component - Load Timezones", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+        global.fetch = vi.fn();
+    });
+
+    it("should load timezones from /timezones.json", async () => {
+        const mockTimezones = { UTC: "UTC", "America/New_York": "EST" };
+
+        global.fetch.mockResolvedValueOnce({
+            json: () => Promise.resolve(mockTimezones),
+        });
+
+        page.loadTimezones();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(global.fetch).toHaveBeenCalledWith("/timezones.json");
+        expect(page.timezones).toEqual(mockTimezones);
+        expect(page.loading.timezones).toBe(false);
+    });
+
+    it("should handle load timezones failure", async () => {
+        global.fetch.mockRejectedValueOnce(new Error("Network error"));
+
+        page.loadTimezones();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(page.dialog.show).toBe(true);
+        expect(page.dialog.type).toBe("error");
+        expect(page.loading.timezones).toBe(false);
+    });
+});
+
+describe("Page Component - Save Settings", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+        global.fetch = vi.fn();
+    });
+
+    it("should save settings to /settings endpoint", async () => {
+        const mockResponse = {
+            message: "Settings saved successfully!",
+            type: "success",
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            json: () => Promise.resolve(mockResponse),
+        });
+
+        page.settings.name = "New Name";
+        page.save();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(global.fetch).toHaveBeenCalledWith("/settings", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: expect.stringContaining("New Name"),
+        });
+        expect(page.saving).toBe(false);
+        expect(page.dialog.type).toBe("success");
+    });
+
+    it("should handle save failure", async () => {
+        global.fetch.mockRejectedValueOnce(new Error("Network error"));
+
+        page.save();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(page.dialog.show).toBe(true);
+        expect(page.dialog.type).toBe("error");
+        expect(page.saving).toBe(false);
+    });
+
+    it("should handle validation errors from server", async () => {
+        const mockResponse = {
+            message: "Validation failed",
+            type: "error",
+            errors: { key: "moduleCount", message: "Invalid value" },
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            json: () => Promise.resolve(mockResponse),
+        });
+
+        page.save();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(page.errors.key).toBe("moduleCount");
+        expect(page.errors.message).toBe("Invalid value");
+    });
+});
+
+describe("Page Component - Reset Settings", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+        global.fetch = vi.fn();
+        global.confirm = vi.fn();
+    });
+
+    it("should reset settings when confirmed", async () => {
+        global.confirm.mockReturnValue(true);
+
+        const mockResponse = {
+            message: "Settings reset successfully!",
+            type: "success",
+        };
+
+        global.fetch.mockResolvedValueOnce({
+            json: () => Promise.resolve(mockResponse),
+        });
+
+        page.reset();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(global.confirm).toHaveBeenCalled();
+        expect(global.fetch).toHaveBeenCalledWith("/settings/reset", {
+            method: "POST",
+        });
+    });
+
+    it("should not reset settings when cancelled", () => {
+        global.confirm.mockReturnValue(false);
+
+        page.reset();
+
+        expect(global.confirm).toHaveBeenCalled();
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});
+
+describe("Page Component - Word Management", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+    });
+
+    it("should add word to multiWords array", () => {
+        page.multiWord = "test";
+        page.addWord();
+        expect(page.multiWords).toContain("test");
+        expect(page.multiWord).toBe("");
+    });
+
+    it("should not add empty word", () => {
+        page.multiWord = "   ";
+        page.addWord();
+        expect(page.multiWords).toEqual([]);
+    });
+
+    it("should remove word at specific index", () => {
+        page.multiWords = ["one", "two", "three"];
+        page.removeWord(1);
+        expect(page.multiWords).toEqual(["one", "three"]);
+    });
+});
+
+describe("Page Component - Update Display", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+        global.fetch = vi.fn();
+    });
+
+    it("should reject delay less than 1 in mode 0", () => {
+        page.settings.mode = 0;
+        page.delay = 0;
+        page.updateDisplay();
+        expect(page.dialog.show).toBe(true);
+        expect(page.dialog.type).toBe("error");
+    });
+
+    it("should reject empty single word in mode 0", () => {
+        page.settings.mode = 0;
+        page.singleMode = true;
+        page.singleWord = "";
+        page.updateDisplay();
+        expect(page.dialog.show).toBe(true);
+        expect(page.dialog.type).toBe("error");
+    });
+
+    it("should reject empty word list in mode 0 multi mode", () => {
+        page.settings.mode = 0;
+        page.singleMode = false;
+        page.multiWords = [];
+        page.updateDisplay();
+        expect(page.dialog.show).toBe(true);
+        expect(page.dialog.type).toBe("error");
+    });
+
+    it("should post mode update for non-zero modes", () => {
+        page.settings.mode = 1;
+        page.updateDisplay();
+        expect(global.fetch).toHaveBeenCalledWith("/settings", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mode: 1 }),
+        });
+    });
+});
+
+describe("Page Component - Processing State", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+    });
+
+    it("should be processing when saving", () => {
+        page.saving = true;
+        expect(page.processing).toBe(true);
+    });
+
+    it("should be processing when loading settings", () => {
+        page.loading.settings = true;
+        expect(page.processing).toBe(true);
+    });
+
+    it("should be processing when loading timezones", () => {
+        page.loading.timezones = true;
+        expect(page.processing).toBe(true);
+    });
+
+    it("should not be processing when idle", () => {
+        page.saving = false;
+        page.loading.settings = false;
+        page.loading.timezones = false;
+        expect(page.processing).toBe(false);
+    });
+});
+
+describe("Page Component - Header", () => {
+    let page;
+
+    beforeEach(() => {
+        page = createPageData();
+    });
+
+    it("should return settings name when set", () => {
+        page.settings.name = "My Display";
+        expect(page.header).toBe("My Display");
+    });
+
+    it("should return default 'Split Flap' when name is empty", () => {
+        page.settings.name = "";
+        expect(page.header).toBe("Split Flap");
+    });
+
+    it("should return default 'Split Flap' when name is undefined", () => {
+        delete page.settings.name;
+        expect(page.header).toBe("Split Flap");
+    });
+});

--- a/src/web/settings.html
+++ b/src/web/settings.html
@@ -449,6 +449,7 @@
                         type="number"
                         id="moduleCount"
                         x-model="settings.moduleCount"
+                        @input="setGroupModuleCount(0, settings.moduleCount)"
                         min="1"
                         max="8"
                         placeholder="1-8"
@@ -525,6 +526,87 @@
                 class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
                 x-cloak
                 x-show="errors.key === 'moduleOffsets'"
+                x-text="errors.message"
+            ></div>
+
+            <h2
+                class="text-xl font-semibold text-left w-full border-b border-gray-600 pb-2 mt-10 mb-2"
+            >
+                Multi-Display Master
+            </h2>
+
+            <label for="masterGroupCount" class="block text-left text-lg mt-4">
+                Number of Groups
+            </label>
+            <input
+                class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-neutral-700 text-gray-100"
+                type="number"
+                id="masterGroupCount"
+                min="1"
+                max="6"
+                x-model.number="settings.masterGroupCount"
+                @input="normalizeMasterGroups()"
+                placeholder="1-6"
+            />
+            <div
+                class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
+                x-cloak
+                x-show="errors.key === 'masterGroupCount'"
+                x-text="errors.message"
+            ></div>
+
+            <div class="w-full mt-4 space-y-3">
+                <template
+                    x-for="(_, i) in Array.from({ length: 6 })"
+                    :key="`group-${i}`"
+                >
+                    <div
+                        class="grid grid-cols-1 sm:grid-cols-3 gap-2 w-full"
+                        x-show="i < settings.masterGroupCount"
+                        x-cloak
+                    >
+                        <div>
+                            <label
+                                class="block text-left text-sm text-gray-300 mb-1"
+                                x-text="`Group ${i + 1}${i === 0 ? ' (local)' : ''}`"
+                            ></label>
+                            <input
+                                type="number"
+                                min="1"
+                                max="8"
+                                class="w-full p-3 text-lg border border-gray-600 rounded-md text-center bg-neutral-700 text-gray-100"
+                                :value="groupModuleArray[i]"
+                                @input="setGroupModuleCount(i, $event.target.value)"
+                                placeholder="Modules"
+                            />
+                        </div>
+                        <div class="sm:col-span-2">
+                            <label
+                                class="block text-left text-sm text-gray-300 mb-1"
+                                x-text="i === 0 ? 'MAC Address' : 'Peer MAC Address'"
+                            ></label>
+                            <input
+                                type="text"
+                                class="w-full p-3 text-lg border border-gray-600 rounded-md text-center bg-neutral-700 text-gray-100 disabled:opacity-60"
+                                :value="i === 0 ? 'local display' : groupMacArray[i]"
+                                @input="setGroupMac(i, $event.target.value)"
+                                :disabled="i === 0"
+                                placeholder="AA:BB:CC:DD:EE:FF"
+                            />
+                        </div>
+                    </div>
+                </template>
+            </div>
+            <div
+                class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
+                x-cloak
+                x-show="errors.key === 'masterGroupModuleCounts'"
+                x-text="errors.message"
+            ></div>
+            <div
+                class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
+                x-cloak
+                x-show="errors.key === 'masterGroupMacs'"
                 x-text="errors.message"
             ></div>
 
@@ -757,6 +839,10 @@
                 >
                     Save Settings
                 </button>
+            </div>
+            <div class="w-full text-left text-sm text-gray-400 mt-2">
+                <span class="font-semibold">Device MAC:</span>
+                <span x-text="localMac || 'Unavailable'"></span>
             </div>
         </div>
         <div

--- a/src/web/settings.html
+++ b/src/web/settings.html
@@ -659,6 +659,57 @@
                     </div>
                 </div>
 
+                <h3 class="block text-left text-lg mt-6 mb-2 font-semibold">
+                    Scrolling (long messages)
+                </h3>
+                <div class="grid grid-cols-2 gap-2 w-full">
+                    <div>
+                        <label
+                            for="scrollDelayMs"
+                            class="block text-left text-lg mt-4"
+                        >
+                            Delay Between Chunks (ms)
+                        </label>
+                        <input
+                            class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-neutral-700 text-gray-100"
+                            type="number"
+                            id="scrollDelayMs"
+                            min="0"
+                            x-model="settings.scrollDelayMs"
+                            placeholder="1500"
+                        />
+                        <div
+                            class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
+                            x-cloak
+                            x-show="errors.key === 'scrollDelayMs'"
+                            x-text="errors.message"
+                        ></div>
+                    </div>
+                    <div>
+                        <label
+                            for="scrollRepeatCount"
+                            class="block text-left text-lg mt-4"
+                        >
+                            Repeat Count
+                        </label>
+                        <input
+                            class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-neutral-700 text-gray-100"
+                            type="number"
+                            id="scrollRepeatCount"
+                            min="1"
+                            max="99"
+                            x-model="settings.scrollRepeatCount"
+                            placeholder="2"
+                        />
+                        <div
+                            class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
+                            x-cloak
+                            x-show="errors.key === 'scrollRepeatCount'"
+                            x-text="errors.message"
+                        ></div>
+                    </div>
+                </div>
+
                 <button
                     class="w-full p-3 mt-4 text-lg font-semibold text-white bg-red-600 rounded-md hover:bg-red-500 transition-colors"
                     x-on:click.prevent="reset()"

--- a/src/web/settings.html
+++ b/src/web/settings.html
@@ -22,6 +22,21 @@
         this.helpTitle = title;
         this.helpContent = content;
         this.showHelp = true;
+    },
+    openCharPanel: null,
+    copyFromModule: 0,
+    toggleCharOffsetPanel(idx) {
+        this.openCharPanel = this.openCharPanel === idx ? null : idx;
+    },
+    getCharOffset(modIdx, charIdx) {
+        const matrix = this.charOffsetMatrix;
+        if (modIdx >= matrix.length || charIdx >= (matrix[modIdx]?.length || 0)) return 0;
+        return matrix[modIdx][charIdx];
+    },
+    allZeroCharOffsets(modIdx) {
+        const matrix = this.charOffsetMatrix;
+        if (modIdx >= matrix.length) return true;
+        return matrix[modIdx].every(v => v === 0);
     }
 })"
         class="flex flex-col items-center justify-center min-h-screen bg-neutral-900 text-gray-100"
@@ -489,7 +504,7 @@
             <div class="grid grid-cols-4 md:grid-cols-8 gap-2 mt-2 w-full">
                 <template
                     x-for="(val, i) in Array.from({ length: settings.moduleCount })"
-                    :key="`addr-${i}-${addressArray[i]}`"
+                    :key="`addr-${i}`"
                 >
                     <input
                         type="number"
@@ -511,7 +526,7 @@
             <div class="grid grid-cols-4 md:grid-cols-8 gap-2 mt-2 w-full">
                 <template
                     x-for="(val, i) in Array.from({ length: settings.moduleCount })"
-                    :key="`off-${i}-${offsetArray[i]}`"
+                    :key="`off-${i}`"
                 >
                     <input
                         type="number"
@@ -526,6 +541,145 @@
                 class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
                 x-cloak
                 x-show="errors.key === 'moduleOffsets'"
+                x-text="errors.message"
+            ></div>
+
+            <h2
+                class="text-xl font-semibold text-left w-full border-b border-gray-600 pb-2 mt-10 mb-2"
+            >
+                Character Offsets
+            </h2>
+            <p class="text-sm text-gray-400 text-left w-full mb-4">
+                Fine-tune each character position per module. Use ▲/▼ to adjust
+                by 1 step.
+            </p>
+
+            <div class="w-full space-y-2">
+                <template
+                    x-for="(val, modIdx) in Array.from({ length: settings.moduleCount })"
+                    :key="`charoff-hdr-${modIdx}`"
+                >
+                    <div
+                        class="border border-gray-600 rounded-md overflow-hidden"
+                    >
+                        <button
+                            type="button"
+                            class="w-full flex items-center justify-between p-3 bg-neutral-700 hover:bg-neutral-600 transition-colors text-left"
+                            @click="toggleCharOffsetPanel(modIdx)"
+                        >
+                            <span class="flex items-center gap-2">
+                                <svg
+                                    class="w-4 h-4 transition-transform"
+                                    :class="{ 'rotate-90': openCharPanel === modIdx }"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                >
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        d="M9 5l7 7-7 7"
+                                    />
+                                </svg>
+                                <span
+                                    class="font-medium"
+                                    x-text="`Module ${modIdx + 1}`"
+                                ></span>
+                            </span>
+                            <span
+                                class="text-xs text-gray-400"
+                                x-show="!allZeroCharOffsets(modIdx)"
+                            >
+                                modified
+                            </span>
+                        </button>
+
+                        <div
+                            x-cloak
+                            x-show="openCharPanel === modIdx"
+                            class="p-3 bg-neutral-800"
+                        >
+                            <div class="flex flex-wrap items-center gap-2 mb-3">
+                                <button
+                                    type="button"
+                                    class="px-3 py-1 text-sm bg-neutral-600 hover:bg-neutral-500 rounded transition-colors"
+                                    @click="resetCharOffsets(modIdx)"
+                                >
+                                    Reset
+                                </button>
+                                <span class="text-sm text-gray-400"
+                                    >Copy from:</span
+                                >
+                                <select
+                                    class="p-1 text-sm border border-gray-600 rounded bg-neutral-700 text-gray-100"
+                                    x-model.number="copyFromModule"
+                                >
+                                    <template
+                                        x-for="(v, ci) in Array.from({ length: settings.moduleCount })"
+                                        :key="`copyopt-${modIdx}-${ci}`"
+                                    >
+                                        <option
+                                            :value="ci"
+                                            :disabled="ci === modIdx"
+                                            x-text="`Module ${ci + 1}`"
+                                        ></option>
+                                    </template>
+                                </select>
+                                <button
+                                    type="button"
+                                    class="px-3 py-1 text-sm bg-neutral-600 hover:bg-neutral-500 rounded transition-colors"
+                                    @click="copyCharOffsets(copyFromModule, modIdx)"
+                                    :disabled="copyFromModule === modIdx"
+                                >
+                                    Copy
+                                </button>
+                            </div>
+
+                            <div
+                                class="grid grid-cols-6 sm:grid-cols-8 md:grid-cols-10 gap-1"
+                            >
+                                <template
+                                    x-for="(ch, charIdx) in charsetChars"
+                                    :key="`co-${modIdx}-${charIdx}`"
+                                >
+                                    <div class="flex flex-col items-center">
+                                        <span
+                                            class="text-xs font-mono text-gray-400 mb-0.5"
+                                            x-text="ch === ' ' ? '⎵' : ch"
+                                        ></span>
+                                        <button
+                                            type="button"
+                                            class="w-full text-xs leading-none text-gray-400 hover:text-amber-500 py-0.5"
+                                            @click="setCharOffset(modIdx, charIdx, getCharOffset(modIdx, charIdx) + 1)"
+                                        >
+                                            ▲
+                                        </button>
+                                        <input
+                                            type="number"
+                                            class="no-buttons w-12 p-1 text-xs border border-gray-600 rounded text-center bg-neutral-700 text-gray-100"
+                                            :value="getCharOffset(modIdx, charIdx)"
+                                            @input="setCharOffset(modIdx, charIdx, $event.target.value)"
+                                        />
+                                        <button
+                                            type="button"
+                                            class="w-full text-xs leading-none text-gray-400 hover:text-amber-500 py-0.5"
+                                            @click="setCharOffset(modIdx, charIdx, getCharOffset(modIdx, charIdx) - 1)"
+                                        >
+                                            ▼
+                                        </button>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            </div>
+
+            <div
+                class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
+                x-cloak
+                x-show="errors.key === 'charOffsets'"
                 x-text="errors.message"
             ></div>
 

--- a/src/web/settings.html
+++ b/src/web/settings.html
@@ -983,7 +983,7 @@
                         for="maxConcurrentMotors"
                         class="block text-left text-lg mt-4"
                     >
-                        Max Motors At Once (homing)
+                        Max Concurrent Motors
                     </label>
                     <input
                         class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-neutral-700 text-gray-100"

--- a/src/web/settings.html
+++ b/src/web/settings.html
@@ -949,6 +949,60 @@
                     </div>
                 </div>
 
+            <h2
+                class="text-xl font-semibold text-left w-full border-b border-gray-600 pb-2 mt-10 mb-2"
+            >
+                Power / Startup
+            </h2>
+
+            <div class="grid grid-cols-2 gap-2 w-full">
+                <div>
+                    <label
+                        for="bootDelayMs"
+                        class="block text-left text-lg mt-4"
+                    >
+                        Boot Delay (ms)
+                    </label>
+                    <input
+                        class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-neutral-700 text-gray-100"
+                        type="number"
+                        id="bootDelayMs"
+                        min="0"
+                        x-model.number="settings.bootDelayMs"
+                        placeholder="2000"
+                    />
+                    <div
+                        class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
+                        x-cloak
+                        x-show="errors.key === 'bootDelayMs'"
+                        x-text="errors.message"
+                    ></div>
+                </div>
+                <div>
+                    <label
+                        for="maxConcurrentMotors"
+                        class="block text-left text-lg mt-4"
+                    >
+                        Max Motors At Once (homing)
+                    </label>
+                    <input
+                        class="w-full p-3 mt-2 text-lg border border-gray-600 rounded-md text-center bg-neutral-700 text-gray-100"
+                        type="number"
+                        id="maxConcurrentMotors"
+                        min="1"
+                        max="8"
+                        x-model.number="settings.maxConcurrentMotors"
+                        placeholder="2"
+                    />
+                    <div
+                        class="w-full p-3 mt-2 text-sm text-white bg-red-700 rounded-md"
+                        x-cloak
+                        x-show="errors.key === 'maxConcurrentMotors'"
+                        x-text="errors.message"
+                    ></div>
+                </div>
+            </div>
+
                 <button
                     class="w-full p-3 mt-4 text-lg font-semibold text-white bg-red-600 rounded-md hover:bg-red-500 transition-colors"
                     x-on:click.prevent="reset()"

--- a/src/web/settings.html
+++ b/src/web/settings.html
@@ -657,7 +657,10 @@
                                         </button>
                                         <input
                                             type="number"
-                                            class="no-buttons w-12 p-1 text-xs border border-gray-600 rounded text-center bg-neutral-700 text-gray-100"
+                                            class="no-buttons w-12 p-1 text-xs border border-gray-600 rounded text-center"
+                                            :class="getCharOffset(modIdx, charIdx) === 0
+                                                ? 'bg-neutral-900 text-gray-600'
+                                                : 'bg-neutral-700 text-gray-100 border-amber-500'"
                                             :value="getCharOffset(modIdx, charIdx)"
                                             @input="setCharOffset(modIdx, charIdx, $event.target.value)"
                                         />

--- a/test/motor_scheduler_test.cpp
+++ b/test/motor_scheduler_test.cpp
@@ -1,0 +1,163 @@
+// Host test for SplitFlapMotorScheduler — the concurrency cap that
+// SplitFlapDisplay::moveTo() uses to bound the boot-homing current spike.
+//
+// This includes the REAL production header (src/SplitFlapMotorScheduler.h);
+// it does not re-implement the logic. It verifies the exact code path the
+// firmware calls: start()/finish() around the stepping loop.
+//
+// Build & run (no Arduino required):
+//   g++ -std=c++11 -Wall -Wextra -I src test/motor_scheduler_test.cpp -o /tmp/motor_scheduler_test && /tmp/motor_scheduler_test
+
+#include <cassert>
+#include <cstdio>
+
+#include "SplitFlapMotorScheduler.h"
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(cond)                                                       \
+    do {                                                                  \
+        checks++;                                                         \
+        if (!(cond)) {                                                    \
+            std::printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);   \
+            failures++;                                                   \
+        }                                                                 \
+    } while (0)
+
+// Simulates a homing move with the scheduler: 8 motors each needing to run,
+// a cap of 2. Motors "finish" after N steps in order; we assert the cap is
+// never exceeded and every motor eventually gets to run.
+static void simulateMove(int numModules, int cap, int stepsPerMotor) {
+    SplitFlapMotorScheduler sched(numModules, cap);
+    int remainingSteps[8] = {0};
+    int activeCount = 0;
+
+    for (int i = 0; i < numModules; i++) {
+        remainingSteps[i] = stepsPerMotor;
+    }
+
+    int guard = 0;
+    while (true) {
+        bool anyLeft = false;
+        for (int i = 0; i < numModules; i++) {
+            if (remainingSteps[i] <= 0) {
+                continue;
+            }
+            anyLeft = true;
+            if (!sched.isRunning(i)) {
+                if (sched.start(i)) {
+                    activeCount++;
+                }
+            }
+            // Only a running motor may consume a step.
+            if (sched.isRunning(i)) {
+                remainingSteps[i]--;
+                if (remainingSteps[i] == 0) {
+                    sched.finish(i);
+                    activeCount--;
+                }
+            }
+        }
+        CHECK(sched.activeCount() == activeCount);
+        CHECK(activeCount <= (cap < 0 ? numModules : cap)); // cap never exceeded
+        if (!anyLeft) {
+            break;
+        }
+        if (++guard > 100000) {
+            std::printf("FAIL: simulated move did not terminate (deadlock)\n");
+            failures++;
+            break;
+        }
+    }
+
+    // All motors must have completed.
+    for (int i = 0; i < numModules; i++) {
+        CHECK(remainingSteps[i] == 0);
+        CHECK(!sched.isRunning(i));
+    }
+    CHECK(sched.activeCount() == 0);
+}
+
+int main() {
+    // --- Basic slot semantics (cap = 2) ---
+    {
+        SplitFlapMotorScheduler sched(8, 2);
+        CHECK(sched.start(0));
+        CHECK(sched.start(1));
+        CHECK(!sched.start(2)); // cap reached
+        CHECK(sched.activeCount() == 2);
+
+        CHECK(sched.start(0)); // already running: no-op, keeps slot
+        CHECK(sched.activeCount() == 2);
+
+        sched.finish(1);
+        CHECK(sched.activeCount() == 1);
+        CHECK(sched.start(2)); // slot freed
+        CHECK(sched.activeCount() == 2);
+
+        sched.finish(0);
+        sched.finish(2);
+        CHECK(sched.activeCount() == 0);
+        CHECK(!sched.isRunning(2));
+    }
+
+    // --- Out-of-range handling ---
+    {
+        SplitFlapMotorScheduler sched(8, 2);
+        CHECK(!sched.start(-1));
+        CHECK(!sched.start(8));  // == numModules
+        CHECK(!sched.start(999));
+        sched.finish(8);         // must not crash / no-op
+        sched.finish(-1);
+        CHECK(sched.activeCount() == 0);
+    }
+
+    // --- Cap = 1: strictly serialized ---
+    {
+        SplitFlapMotorScheduler sched(8, 1);
+        CHECK(sched.start(0));
+        CHECK(!sched.start(1));
+        CHECK(!sched.start(2));
+        sched.finish(0);
+        CHECK(sched.start(1));
+        CHECK(!sched.start(2));
+        CHECK(sched.activeCount() == 1);
+    }
+
+    // --- Cap = -1: unlimited (normal message writes) ---
+    {
+        SplitFlapMotorScheduler sched(8, -1);
+        for (int i = 0; i < 8; i++) {
+            CHECK(sched.start(i));
+        }
+        CHECK(sched.activeCount() == 8);
+    }
+
+    // --- Cap = 0 must not deadlock the caller (clamped to 1 motor) ---
+    // Homing clamps to >= 1 via constrain() in SplitFlapDisplay.cpp, but
+    // the scheduler guards anyway.
+    {
+        SplitFlapMotorScheduler sched(8, 0);
+        CHECK(sched.start(0));
+        CHECK(!sched.start(1));
+        sched.finish(0);
+        CHECK(sched.start(1));
+    }
+
+    // --- Full homing simulations across caps/module counts ---
+    simulateMove(8, 2, 2048); // 8 modules, cap 2, full rotation each
+    simulateMove(3, 2, 2048); // 3 modules (slave group)
+    simulateMove(11 > 8 ? 8 : 11, 2, 2048); // scheduler max is 8 modules per board
+    simulateMove(8, 1, 2048); // strictly serialized homing
+    simulateMove(8, 4, 2048);
+    simulateMove(8, -1, 2048); // uncapped must also complete correctly
+    simulateMove(8, 2, 1);     // tiny moves
+
+    if (failures == 0) {
+        std::printf("PASS: motor scheduler (%d checks)\n", checks);
+        return 0;
+    }
+    std::printf("FAIL: %d/%d checks failed\n", failures, checks);
+    return 1;
+}

--- a/test/multi_group_mqtt_state_test.cpp
+++ b/test/multi_group_mqtt_state_test.cpp
@@ -1,0 +1,229 @@
+// Unit test for SplitFlapMqtt::setup() callback dispatch.
+//
+// Bug: in multi-group mode (masterGroupCount > 1) the MQTT callback routed
+// messages through EspNow->distributeMessage() but never called publishState().
+// The retained splitflap/splitflap/state topic therefore stayed stale.
+//
+// Fix: after distributeMessage() returns in the multi-group branch, publish
+// the FULL original message to the state topic. Single-group continues to
+// publish via display->writeString() (publishState defaults to true) — no
+// change there, so we do not double-publish.
+//
+// This test re-implements the dispatch logic in pure C++ so it can run on
+// the host without Arduino. It exercises the exact branch that changed.
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cstring>
+
+// ---- Mocks ----
+struct MockEspNow {
+    int distributeCount = 0;
+    std::string lastMessage;
+    void distributeMessage(const std::string& msg) {
+        distributeCount++;
+        lastMessage = msg;
+    }
+};
+
+struct MockDisplay {
+    int writeCount = 0;
+    bool lastPublishState = false;
+    std::string lastMessage;
+    MockEspNow* lastEspNowPtr = nullptr;  // for verifying dispatch path
+
+    // writeString has publishState=true by default; we use a flag to simulate
+    // whether it would have published (it always publishes when called via
+    // the single-group branch above).
+    void writeString(const std::string& msg, bool publishState) {
+        writeCount++;
+        lastMessage = msg;
+        lastPublishState = publishState;
+    }
+};
+
+struct MockMqttClient {
+    bool connected = true;
+    int publishCount = 0;
+    std::vector<std::string> publishedStates;
+    bool isConnected() const { return connected; }
+    void publishState(const std::string& msg) {
+        publishCount++;
+        publishedStates.push_back(msg);
+    }
+};
+
+// ---- Re-implementation of the dispatch logic (post-fix) ----
+//
+// Mirrors src/SplitFlapMqtt.cpp lines 22-46. The only difference from
+// the production code is the lambda capture of `this` is a struct
+// reference, and there's no Serial.printf.
+//
+// Pre-fix version (for negative test): no publishState() call after
+// distributeMessage(). Post-fix version: publishState() called.
+
+struct PreFixDispatcher {
+    MockMqttClient& mqttClient;
+    MockDisplay& display;
+    MockEspNow* espNow = nullptr;  // can be null in single-group
+    int masterGroupCount = 1;
+    int moduleCount = 8;
+
+    // Pre-fix behavior: multi-group path does NOT publish.
+    void onMessage(const std::string& message) {
+        if (masterGroupCount > 1 && espNow) {
+            espNow->distributeMessage(message);
+        } else {
+            display.writeString(message, true);  // publishState=true (default)
+        }
+    }
+};
+
+struct PostFixDispatcher {
+    MockMqttClient& mqttClient;
+    MockDisplay& display;
+    MockEspNow* espNow = nullptr;
+    int masterGroupCount = 1;
+    int moduleCount = 8;
+
+    // Post-fix behavior: multi-group path publishes the full original
+    // message via publishState() after distributeMessage() returns.
+    void onMessage(const std::string& message) {
+        if (masterGroupCount > 1 && espNow) {
+            espNow->distributeMessage(message);
+            if (mqttClient.isConnected()) {
+                mqttClient.publishState(message);
+            }
+        } else {
+            display.writeString(message, true);
+        }
+    }
+};
+
+// ---- Tests ----
+
+static int testFailures = 0;
+static int testCount = 0;
+
+#define EXPECT(cond, label) do { \
+    testCount++; \
+    if (!(cond)) { \
+        std::cout << "  FAIL: " << label << std::endl; \
+        testFailures++; \
+    } else { \
+        std::cout << "  ok:   " << label << std::endl; \
+    } \
+} while (0)
+
+void testPreFix_MultiGroupNoPublish() {
+    std::cout << "\n[TEST] pre-fix: multi-group does NOT publish (reproduces the bug)" << std::endl;
+    MockMqttClient mqtt;
+    MockDisplay display;
+    MockEspNow espNow;
+    PreFixDispatcher d{mqtt, display, &espNow, /*masterGroupCount=*/2, 8};
+    const std::string msg = "HELLO WORLD";
+
+    d.onMessage(msg);
+
+    EXPECT(espNow.distributeCount == 1, "espNow.distributeMessage called");
+    EXPECT(display.writeCount == 0, "display.writeString NOT called in multi-group path");
+    EXPECT(mqtt.publishCount == 0, "BUG: no MQTT state publish (this is the bug)");
+}
+
+void testPostFix_MultiGroupPublishesFullMessage() {
+    std::cout << "\n[TEST] post-fix: multi-group publishes FULL original message" << std::endl;
+    MockMqttClient mqtt;
+    MockDisplay display;
+    MockEspNow espNow;
+    PostFixDispatcher d{mqtt, display, &espNow, /*masterGroupCount=*/2, 8};
+    const std::string msg = "HELLO WORLD THIS IS A LONG MESSAGE";  // 34 chars
+
+    d.onMessage(msg);
+
+    EXPECT(espNow.distributeCount == 1, "espNow.distributeMessage called");
+    EXPECT(display.writeCount == 0, "display.writeString NOT called in multi-group path");
+    EXPECT(mqtt.publishCount == 1, "MQTT state publish called exactly once");
+    EXPECT(mqtt.publishedStates.size() == 1 && mqtt.publishedStates[0] == msg,
+           "published the FULL 34-char original message (not a chunk)");
+}
+
+void testPostFix_SingleGroupUnchanged() {
+    std::cout << "\n[TEST] post-fix: single-group behavior unchanged" << std::endl;
+    MockMqttClient mqtt;
+    MockDisplay display;
+    MockEspNow espNow;  // present but unused
+    PostFixDispatcher d{mqtt, display, &espNow, /*masterGroupCount=*/1, 8};
+    const std::string msg = "HELLO";
+
+    d.onMessage(msg);
+
+    EXPECT(espNow.distributeCount == 0, "espNow.distributeMessage NOT called in single-group");
+    EXPECT(display.writeCount == 1, "display.writeString called once (existing behavior)");
+    EXPECT(display.lastPublishState == true, "writeString called with publishState=true");
+    EXPECT(mqtt.publishCount == 0,
+           "no extra publishState() call in single-group (writeString handles it - no double publish)");
+}
+
+void testPostFix_MultiGroupBrokerDisconnected() {
+    std::cout << "\n[TEST] post-fix: multi-group, broker disconnected" << std::endl;
+    MockMqttClient mqtt;
+    mqtt.connected = false;
+    MockDisplay display;
+    MockEspNow espNow;
+    PostFixDispatcher d{mqtt, display, &espNow, /*masterGroupCount=*/2, 8};
+
+    d.onMessage("HELLO");
+
+    EXPECT(espNow.distributeCount == 1, "distribution still happens");
+    EXPECT(mqtt.publishCount == 0, "no publish attempt when broker disconnected");
+}
+
+void testPostFix_MultiGroupThreeGroups() {
+    std::cout << "\n[TEST] post-fix: multi-group, 3 groups" << std::endl;
+    MockMqttClient mqtt;
+    MockDisplay display;
+    MockEspNow espNow;
+    PostFixDispatcher d{mqtt, display, &espNow, /*masterGroupCount=*/3, 8};
+    const std::string msg = "TUESDAY";
+
+    d.onMessage(msg);
+
+    EXPECT(mqtt.publishCount == 1, "publishes once for 3-group setup");
+    EXPECT(mqtt.publishedStates[0] == msg, "publishes the full message");
+}
+
+void testPostFix_MultiGroupNoEspNowWired() {
+    std::cout << "\n[TEST] post-fix: multi-group setting but no EspNow (degraded fallback)" << std::endl;
+    MockMqttClient mqtt;
+    MockDisplay display;
+    // espNow == nullptr: condition `masterGroupCount > 1 && espNow` is false,
+    // so we fall through to the single-group path. This documents the
+    // existing degraded behavior (not changed by the fix).
+    PostFixDispatcher d{mqtt, display, /*espNow=*/nullptr, /*masterGroupCount=*/2, 8};
+
+    d.onMessage("HELLO");
+
+    EXPECT(display.writeCount == 1, "falls back to display.writeString when espNow null");
+    EXPECT(mqtt.publishCount == 0, "no extra publish (writeString handles it)");
+}
+
+int main() {
+    std::cout << "=== SplitFlapMqtt callback dispatch - regression tests ===" << std::endl;
+    testPreFix_MultiGroupNoPublish();
+    testPostFix_MultiGroupPublishesFullMessage();
+    testPostFix_SingleGroupUnchanged();
+    testPostFix_MultiGroupBrokerDisconnected();
+    testPostFix_MultiGroupThreeGroups();
+    testPostFix_MultiGroupNoEspNowWired();
+
+    std::cout << "\n=== Summary ===" << std::endl;
+    std::cout << "Passed: " << (testCount - testFailures) << "/" << testCount << std::endl;
+    if (testFailures == 0) {
+        std::cout << "ALL TESTS PASSED" << std::endl;
+        return 0;
+    } else {
+        std::cout << testFailures << " TEST(S) FAILED" << std::endl;
+        return 1;
+    }
+}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -18,6 +18,12 @@ export default defineConfig({
             },
         },
     },
+    test: {
+        environment: "jsdom",
+        globals: true,
+        root: ".",
+        include: ["src/web/**/*.test.js"],
+    },
     plugins: [
         tailwindcss(),
         {


### PR DESCRIPTION
## Problem

With 11 modules (2 groups: 8 + 3) on a shared 5V rail, the display fails at power-on: **no module ever moves** and the rail reads <3V. With 10 modules the rail holds at >3.2V and everything works.

### Root cause — power-on state of the PCF8575

The PCF8575 I/O expanders power up with **all outputs HIGH**, and the ULN2003 driver boards invert that signal. So at power-on **every coil of every module is energized** until the firmware writes the outputs low — which the old code only did *after* `STARTUP_DELAY` (2s) + web server init + WiFi connect (seconds total). 11 modules × up to 4 coils ≈ 4A+ sustained during that whole window. 10 modules just barely survive; the 11th tips the rail under the ESP32 brownout threshold, and the board brownout-loops before the display ever initializes.

### Changes

1. **Coils off immediately at boot** — `display.init()` (which writes the init state + `stop()` to every module) now runs as the **first thing** in `setup()`, before the boot delay and network bring-up. The coil-energized window shrinks from seconds to milliseconds.
2. **`STARTUP_DELAY` → `bootDelayMs` setting** (default 2000, per-device via web UI). In multi-display setups set the slave's value a few seconds higher than the master's so the two boards never energize motors or transmit WiFi at the same time.
3. **Concurrency-capped homing** — new `SplitFlapMotorScheduler` bounds how many motors are energized at once. `moveTo()` now: only energizes motors that actually need to move, starts them as slots free up, and releases coils the instant a motor reaches its target (previously *all* motors were energized for the whole move, including ones that never moved). Homing paths use the new `maxConcurrentMotors` setting (default 2); normal message writes stay uncapped and keep their original timing.
4. **Removed the 4×100ms "prime" steps in `SplitFlapModule::init()`** — no functional purpose (homing finds the magnet via the hall sensor), and it drew coil current in exactly the weakest boot window.
5. Drive-by: fixed swapped arguments in `homeToChar` (`moveTo(targetPositions, true, speed)` passed `speed=true`, `releaseMotors=MAX_RPM`).

## Verification

- `pio run -e esp32_c3` — SUCCESS (RAM 16.4%, Flash 58.1%)
- `pio run -e esp32_s3` — SUCCESS
- `test/motor_scheduler_test.cpp` — compiles the **real** `src/SplitFlapMotorScheduler.h` (the exact code `moveTo()` calls), no reimplementation: **86,144 checks pass**, including full 8-module homing simulations at caps 1/2/4/unlimited verifying the cap is never exceeded and all modules complete (no deadlock).

## What this does NOT fix (hardware)

The ~300ms ROM-boot window before `setup()` runs is still hardware — the ESP32 boots before the firmware can write the expanders low. If the PSU is *really* at its limit, that window can still sag. Recommended if the firmware changes alone don't get 11 modules booting:

- PSU rated **≥4A at 5V** for 11 modules + 2 ESP32s (currently it's marginal — 10 modules already sag to 3.2V at power-on)
- **1000–2200µF bulk cap** on the 5V rail near the load to ride out the ROM-boot window
- One-module bench test to rule out a shorted/miswired 11th module

## Settings (web UI → Power / Startup)

| Setting | Default | Meaning |
|---|---|---|
| `bootDelayMs` | 2000 | Power-on settle; set slave higher than master |
| `maxConcurrentMotors` | 2 | Cap on simultaneously energized motors during homing |
