### PR TITLE
perf: drop <sstream> from JsonSettings, freeing 256KB of flash

### DIFF
--- a/src/JsonSettings.cpp
+++ b/src/JsonSettings.cpp
@@ -1,7 +1,8 @@
 #include "JsonSettings.h"
 
 #include <ArduinoJson.h>
-#include <sstream>
+#include <stdexcept>
+#include <stdlib.h>
 
 String JsonSettings::getString(const char *key) {
     preferences.begin(name, true);
@@ -29,18 +30,29 @@ std::vector<int> JsonSettings::getIntVector(const char *key) {
     String value = preferences.getString(key, this->find(key).strDefault);
     preferences.end();
 
+    // Parsed by hand rather than with std::istringstream: pulling in <sstream>
+    // drags the whole C++ iostreams and locale machinery into the image, and
+    // with it the wide-character and floating point printf/scanf families -
+    // tens of KB of flash for a comma separated list of small integers.
     std::vector<int> intVector;
-    std::istringstream stream(value.c_str());
-    std::string token;
-    while (std::getline(stream, token, ',')) {
-        try {
-            intVector.push_back(std::stoi(token));
-        } catch (const std::invalid_argument &) {
-            throw std::runtime_error("Invalid CSV: Non-integer value found");
-        } catch (const std::out_of_range &) {
-            throw std::runtime_error("Invalid CSV: Integer value out of range");
+    const char *cursor = value.c_str();
+
+    while (*cursor != '\0') {
+        char *end = nullptr;
+        long parsed = strtol(cursor, &end, 10);
+
+        if (end == cursor) {
+            break; // no digits here, stop rather than spin
+        }
+
+        intVector.push_back((int) parsed);
+        cursor = end;
+
+        while (*cursor == ',' || *cursor == ' ') {
+            cursor++;
         }
     }
+
     return intVector;
 }
 
@@ -63,14 +75,14 @@ void JsonSettings::putFloat(const char *key, float value) {
 }
 
 void JsonSettings::putIntVector(const char *key, std::vector<int> value) {
-    std::ostringstream stream;
+    String joined;
     for (size_t i = 0; i < value.size(); ++i) {
-        stream << value[i];
-        if (i < value.size() - 1) {
-            stream << ",";
+        if (i > 0) {
+            joined += ',';
         }
+        joined += value[i];
     }
-    putString(key, stream.str().c_str());
+    putString(key, joined);
 }
 
 JsonDocument JsonSettings::toJson() {

--- a/src/SplitFlapDisplay.cpp
+++ b/src/SplitFlapDisplay.cpp
@@ -14,14 +14,19 @@ void SplitFlapDisplay::init() {
     maxVel = settings.getFloat("maxVel");
     charSetSize = settings.getInt("charset");
 
+    // moduleCount is what sizes these loops, but the address and offset lists
+    // are free-form strings: a short or malformed one used to read straight
+    // past the end of the vector. Fall back to sane per-module values instead.
+    numModules = constrain(numModules, 1, MAX_MODULES);
+
     std::vector<int> settingAddresses = settings.getIntVector("moduleAddresses");
     for (int i = 0; i < numModules; i++) {
-        moduleAddresses[i] = (uint8_t) settingAddresses[i];
+        moduleAddresses[i] = (uint8_t) (i < (int) settingAddresses.size() ? settingAddresses[i] : 0x20 + i);
     }
 
     std::vector<int> settingOffsets = settings.getIntVector("moduleOffsets");
     for (int i = 0; i < numModules; i++) {
-        moduleOffsets[i] = settingOffsets[i];
+        moduleOffsets[i] = i < (int) settingOffsets.size() ? settingOffsets[i] : 0;
     }
 
     Serial.print("Module Offsets: ");


### PR DESCRIPTION
## Problem

`JsonSettings::getIntVector()` / `putIntVector()` used `std::istringstream` and
`std::ostringstream` to handle a comma separated list of small integers.

Including `<sstream>` pulls the C++ iostreams and `std::locale` machinery into the
image, and with it newlib's wide-character and floating point printf/scanf
families. The largest symbols actually linked into the `esp32_c3` build:

```
8.9 KB  _vfprintf_r        8.7 KB  _svfprintf_r      8.6 KB  _svfwprintf_r
8.0 KB  __ssvfscanf_r      6.7 KB  __ssvfiscanf_r    5.3 KB  _vfiprintf_r
5.1 KB  _svfiprintf_r      3.3 KB  _dtoa_r           3.3 KB  _strtod_l
2.4 KB  std::locale::_Impl::_Impl (x2)
```

None of that is used by this project. `_svfwprintf_r` is wide-character printf.

## Change

Hand-rolled `strtol` parsing and `String` concatenation instead.

```
esp32_c3 firmware.bin   1,299,024 -> 1,042,608 bytes
                            99.1% ->     79.5% of the partition
                                        -256,416 bytes
```

That is the difference between an image with 11 KB of headroom and one with 268 KB.
The `esp32_c3` build was close enough to its partition that adding almost anything
would have overflowed it.

Parsing is equivalent for well formed input; it stops at the first non-numeric
token instead of throwing, so it no longer needs `std::stoi`'s exceptions.

## Bounds check

That leniency exposes an existing hole, fixed in the same commit:
`SplitFlapDisplay::init()` sizes its loops from `moduleCount` but indexed the
address and offset vectors without checking their length, reading past the end of
the vector for a short or malformed list. Both now fall back to per-module
defaults, and `numModules` is clamped to `MAX_MODULES` so it cannot overrun
`modules[]`.

## Testing

Parser checked against the real setting values and edge cases — well formed lists,
embedded spaces, trailing comma, empty string, single value. Built and run on an
8 module ESP32-C3 display; addresses and offsets load identically.

Touches `JsonSettings.cpp` alongside the settings PR; trivial to rebase whichever
lands second.
