### PR TITLE
fix: settings writes silently lost, and unknown keys panic the device

### DIFF
--- a/src/JsonSettings.cpp
+++ b/src/JsonSettings.cpp
@@ -4,6 +4,8 @@
 #include <sstream>
 
 String JsonSettings::getString(const char *key) {
+    Guard guard(mutex);
+
     preferences.begin(name, true);
     String value = preferences.getString(key, this->find(key).strDefault);
     preferences.end();
@@ -11,6 +13,8 @@ String JsonSettings::getString(const char *key) {
 }
 
 int JsonSettings::getInt(const char *key) {
+    Guard guard(mutex);
+
     preferences.begin(name, true);
     int value = preferences.getInt(key, this->find(key).intDefault);
     preferences.end();
@@ -18,6 +22,8 @@ int JsonSettings::getInt(const char *key) {
 }
 
 float JsonSettings::getFloat(const char *key) {
+    Guard guard(mutex);
+
     preferences.begin(name, true);
     float value = preferences.getFloat(key, this->find(key).floatDefault);
     preferences.end();
@@ -25,6 +31,8 @@ float JsonSettings::getFloat(const char *key) {
 }
 
 std::vector<int> JsonSettings::getIntVector(const char *key) {
+    Guard guard(mutex);
+
     preferences.begin(name, true);
     String value = preferences.getString(key, this->find(key).strDefault);
     preferences.end();
@@ -45,18 +53,24 @@ std::vector<int> JsonSettings::getIntVector(const char *key) {
 }
 
 void JsonSettings::putString(const char *key, String value) {
+    Guard guard(mutex);
+
     preferences.begin(name, false);
     preferences.putString(key, value);
     preferences.end();
 }
 
 void JsonSettings::putInt(const char *key, int value) {
+    Guard guard(mutex);
+
     preferences.begin(name, false);
     preferences.putInt(key, value);
     preferences.end();
 }
 
 void JsonSettings::putFloat(const char *key, float value) {
+    Guard guard(mutex);
+
     preferences.begin(name, false);
     preferences.putFloat(key, value);
     preferences.end();
@@ -74,6 +88,8 @@ void JsonSettings::putIntVector(const char *key, std::vector<int> value) {
 }
 
 JsonDocument JsonSettings::toJson() {
+    Guard guard(mutex);
+
     JsonDocument settings;
 
     preferences.begin(name, true);
@@ -99,6 +115,8 @@ JsonDocument JsonSettings::toJson() {
 }
 
 bool JsonSettings::fromJson(JsonDocument settings) {
+    Guard guard(mutex);
+
     preferences.begin(name, false);
 
     for (JsonPair kv : settings.as<JsonObject>()) {
@@ -138,6 +156,8 @@ bool JsonSettings::fromJson(JsonDocument settings) {
 }
 
 bool JsonSettings::reset() {
+    Guard guard(mutex);
+
     preferences.begin("config", false);
     preferences.clear();
     preferences.end();

--- a/src/JsonSettings.cpp
+++ b/src/JsonSettings.cpp
@@ -103,11 +103,24 @@ bool JsonSettings::fromJson(JsonDocument settings) {
 
     for (JsonPair kv : settings.as<JsonObject>()) {
         const char *key = kv.key().c_str();
+
+        // Skip keys we do not know about instead of letting find() throw. This
+        // body runs on the web server task, where an uncaught exception panics
+        // the whole device - and a browser still holding a page from a
+        // different firmware version will happily post keys we have never
+        // heard of.
+        if (this->map.find(key) == this->map.end()) {
+            Serial.print("Ignoring unknown setting: ");
+            Serial.println(key);
+            continue;
+        }
+
         JsonSetting setting = this->find(key);
 
         if (! setting.validate(kv.value().as<String>())) {
             lastValidationError = setting.getLastValidationError();
             lastValidationKey = String(key);
+            preferences.end(); // do not leak the nvs handle on the error path
             return false;
         }
 

--- a/src/JsonSettings.h
+++ b/src/JsonSettings.h
@@ -5,11 +5,14 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <Preferences.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 #include <map>
 
 class JsonSettings {
   public:
-    JsonSettings(const char *name, std::map<String, JsonSetting> map) : name(name), map(map) {}
+    JsonSettings(const char *name, std::map<String, JsonSetting> map)
+        : name(name), map(map), mutex(xSemaphoreCreateRecursiveMutex()) {}
 
     String getString(const char *key);
     int getInt(const char *key);
@@ -36,6 +39,32 @@ class JsonSettings {
     String lastValidationKey;
 
     JsonSetting find(const char *key);
+
+    // Every accessor below opens and closes NVS on the single `preferences`
+    // instance. The Arduino loop task reads settings (getMode() runs on every
+    // pass through loop()) while the AsyncTCP task writes them from the HTTP
+    // handlers, so without this lock one task's end() closes the handle the
+    // other is mid-way through using: reads silently fall back to the compiled
+    // default and writes are lost while the request still answers "success".
+    //
+    // Recursive because reset() calls fromJson(toJson()), and both take it.
+    SemaphoreHandle_t mutex;
+
+    class Guard {
+      public:
+        explicit Guard(SemaphoreHandle_t mutex) : mutex(mutex) {
+            xSemaphoreTakeRecursive(mutex, portMAX_DELAY);
+        }
+        ~Guard() {
+            xSemaphoreGiveRecursive(mutex);
+        }
+
+        Guard(const Guard &) = delete;
+        Guard &operator=(const Guard &) = delete;
+
+      private:
+        SemaphoreHandle_t mutex;
+    };
 
     Preferences preferences;
 };


### PR DESCRIPTION
## 1. Settings writes are lost, and the request still says "success"

`JsonSettings` shares one `Preferences` instance between the Arduino loop task and
the AsyncTCP task that serves the HTTP handlers, with no lock, and every accessor
opens and closes NVS around a single get or put:

```cpp
int JsonSettings::getInt(const char *key) {
    preferences.begin(name, true);
    int value = preferences.getInt(key, this->find(key).intDefault);
    preferences.end();          // closes the shared handle
    return value;
}
```

`loop()` calls `getMode()` on every pass, so this runs thousands of times a second
while the web handlers write from another task. One task's `end()` closes the
handle the other is part way through: the read falls back to the compiled default,
the write is dropped, and the browser is told it succeeded.

Observed on an 8 module display: a `POST /text` returned `success`, `mode` read
back as `0` — the compiled default for that key — then reverted, and the display
never changed mode. A later `POST /settings` reported success without storing
anything and only took on the second attempt.

All accessors now take a recursive mutex; recursive because `reset()` calls
`fromJson(toJson())` and all three take it. After the change, 12 of 12 consecutive
write-then-read-back cycles matched.

## 2. An unknown settings key panics the device

`find()` throws `std::runtime_error` for keys that are not in the settings map, and
`fromJson()` calls it on every key of the posted JSON with no `try`/`catch`
anywhere above it. The exception escapes on the web server task and takes the whole
device down.

Any browser holding a settings page from a different firmware version will post
keys this build has never heard of, which is enough to reboot the display from the
UI. Unknown keys are now logged and skipped.

Also releases the NVS handle on the validation-failure path, which returned without
calling `end()`.

## Testing

Built and run on an 8 module ESP32-C3 display. Mismatched-key case exercised by
posting a settings body containing a key the firmware does not define.

Touches `JsonSettings.cpp` alongside the `<sstream>` PR; trivial to rebase
whichever lands second.
